### PR TITLE
I64Extend16S should operate on 16 bits, not 8.

### DIFF
--- a/lib/wasm/src/code_translator.rs
+++ b/lib/wasm/src/code_translator.rs
@@ -654,7 +654,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I64Extend16S => {
             let val = state.pop1();
-            state.push1(builder.ins().ireduce(I8, val));
+            state.push1(builder.ins().ireduce(I16, val));
             let val = state.pop1();
             state.push1(builder.ins().sextend(I64, val));
         }


### PR DESCRIPTION
This showed up in clippy warnings as the code for this case was
the same as for `I64Extend8S`.