### PR TITLE
Fix check-rustfmt.sh for macOS

### DIFF
--- a/check-rustfmt.sh
+++ b/check-rustfmt.sh
@@ -22,11 +22,11 @@ set -euo pipefail
 # operation, however that doesn't appear to be possible through "cargo fmt").
 VERS="0.9.0"
 
-if cargo install --list | grep -q "^rustfmt v$VERS"; then
+if cargo install --list | tee /dev/null | grep -q "^rustfmt v$VERS"; then
     exit 0
 fi
 
-if [ "$1" != "--install" ]; then
+if [[ ${1:-""} != "--install" ]]; then
     echo "********************************************************************"
     echo "*  Please install rustfmt v$VERS to verify formatting.             *"
     echo "*  If a newer version of rustfmt is available, update this script. *"


### PR DESCRIPTION
**Disclaimer**: I'm not a bash wizard and I have no idea what I'm doing.

There are two cases:

1. It seems that grep on macOS exits as soon as it finds the first match. This makes cargo unhappy and it prints message like "failed printing to stdout: Broken pipe (os error 32)". The solution is to fully consume the output from cargo. I choose to use tee for this task.

2. When in a strict mode, bash complains that $1 is not defined (when it's actually not defined in case of omitting --install). The solution is to apply bash substitution magic: when $1 is undefined or set to null substitute it with empty string.