### PR TITLE
Use clippy

### DIFF
--- a/check-clippy.sh
+++ b/check-clippy.sh
@@ -5,16 +5,6 @@ set -euo pipefail
 
 if cargo install --list | tee /dev/null | grep -q "^clippy v0"; then
     exit 0
-fi
-
-if [[ ${1:-""} != "--install" ]]; then
-    echo "********************************************************************"
-    echo "*  Please install clippy to lint rust code.                        *"
-    echo "********************************************************************"
-    echo "$0 --install"
-    sleep 1
+else
     exit 1
 fi
-
-echo "Installing clippy"
-cargo +nightly install clippy

--- a/check-clippy.sh
+++ b/check-clippy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: check-clippy.sh [--install]
+
+if cargo install --list | tee /dev/null | grep -q "^clippy v0"; then
+    exit 0
+fi
+
+if [[ ${1:-""} != "--install" ]]; then
+    echo "********************************************************************"
+    echo "*  Please install clippy to lint rust code.                        *"
+    echo "********************************************************************"
+    echo "$0 --install"
+    sleep 1
+    exit 1
+fi
+
+echo "Installing clippy"
+cargo +nightly install clippy

--- a/clippy-all.sh
+++ b/clippy-all.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+# Check all sources with clippy.
+# In the cton-util crate (root dir) clippy will only work with nightly cargo -
+# there is a bug where it will reject the commands passed to it by cargo 0.25.0
+cargo +nightly clippy --all

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = [ "WebAssembly" ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = [ "WebAssembly" ]
+doc-valid-idents = [ "WebAssembly", "NaN" ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = [ "WebAssembly", "NaN" ]
+doc-valid-idents = [ "WebAssembly", "NaN", "SetCC" ]

--- a/lib/cretonne/meta/gen_settings.py
+++ b/lib/cretonne/meta/gen_settings.py
@@ -28,7 +28,7 @@ def gen_enum_types(sgrp, fmt):
         if not isinstance(setting, EnumSetting):
             continue
         ty = camel_case(setting.name)
-        fmt.doc_comment('Values for {}.'.format(setting))
+        fmt.doc_comment('Values for `{}`.'.format(setting))
         fmt.line('#[derive(Debug, PartialEq, Eq)]')
         with fmt.indented('pub enum {} {{'.format(ty), '}'):
             for v in setting.values:

--- a/lib/cretonne/src/bforest/path.rs
+++ b/lib/cretonne/src/bforest/path.rs
@@ -437,7 +437,7 @@ impl<F: Forest> Path<F> {
 
         // Discard the root node if it has shrunk to a single sub-tree.
         let mut ns = 0;
-        while let &NodeData::Inner { size: 0, ref tree, .. } = &pool[self.node[ns]] {
+        while let NodeData::Inner { size: 0, ref tree, .. } = pool[self.node[ns]] {
             ns += 1;
             self.node[ns] = tree[0];
         }

--- a/lib/cretonne/src/bforest/path.rs
+++ b/lib/cretonne/src/bforest/path.rs
@@ -529,12 +529,11 @@ impl<F: Forest> Path<F> {
             // current entry[level] was one off the end of the node, it will now point at a proper
             // entry.
             debug_assert!(usize::from(self.entry[level]) < pool[self.node[level]].entries());
-        } else {
+
+        } else if usize::from(self.entry[level]) >= pool[self.node[level]].entries() {
             // There's no right sibling at this level, so the node can't be rebalanced.
             // Check if we are in an off-the-end position.
-            if usize::from(self.entry[level]) >= pool[self.node[level]].entries() {
-                self.size = 0;
-            }
+            self.size = 0;
         }
     }
 

--- a/lib/cretonne/src/bforest/pool.rs
+++ b/lib/cretonne/src/bforest/pool.rs
@@ -57,6 +57,7 @@ impl<F: Forest> NodePool<F> {
     pub fn free_tree(&mut self, node: Node) {
         if let NodeData::Inner { size, tree, .. } = self[node] {
             // Note that we have to capture `tree` by value to avoid borrow checker trouble.
+            #[cfg_attr(feature="cargo-clippy", allow(needless_range_loop))]
             for i in 0..usize::from(size + 1) {
                 // Recursively free sub-trees. This recursion can never be deeper than `MAX_PATH`,
                 // and since most trees have less than a handful of nodes, it is worthwhile to

--- a/lib/cretonne/src/bforest/pool.rs
+++ b/lib/cretonne/src/bforest/pool.rs
@@ -57,7 +57,7 @@ impl<F: Forest> NodePool<F> {
     pub fn free_tree(&mut self, node: Node) {
         if let NodeData::Inner { size, tree, .. } = self[node] {
             // Note that we have to capture `tree` by value to avoid borrow checker trouble.
-            #[cfg_attr(feature="cargo-clippy", allow(needless_range_loop))]
+            #[cfg_attr(feature = "cargo-clippy", allow(needless_range_loop))]
             for i in 0..usize::from(size + 1) {
                 // Recursively free sub-trees. This recursion can never be deeper than `MAX_PATH`,
                 // and since most trees have less than a handful of nodes, it is worthwhile to

--- a/lib/cretonne/src/binemit/relaxation.rs
+++ b/lib/cretonne/src/binemit/relaxation.rs
@@ -76,7 +76,7 @@ pub fn relax_branches(func: &mut Function, isa: &TargetIsa) -> Result<CodeOffset
                 if let Some(range) = encinfo.branch_range(enc) {
                     if let Some(dest) = cur.func.dfg[inst].branch_destination() {
                         let dest_offset = cur.func.offsets[dest];
-                        // This coubd be an out-of-range branch.
+                        // This could be an out-of-range branch.
                         // Relax it unless the destination offset has not been computed yet.
                         if !range.contains(offset, dest_offset) &&
                             (dest_offset != 0 || Some(dest) == cur.func.layout.entry_block())

--- a/lib/cretonne/src/binemit/relaxation.rs
+++ b/lib/cretonne/src/binemit/relaxation.rs
@@ -76,14 +76,13 @@ pub fn relax_branches(func: &mut Function, isa: &TargetIsa) -> Result<CodeOffset
                 if let Some(range) = encinfo.branch_range(enc) {
                     if let Some(dest) = cur.func.dfg[inst].branch_destination() {
                         let dest_offset = cur.func.offsets[dest];
-                        if !range.contains(offset, dest_offset) {
-                            // This is an out-of-range branch.
-                            // Relax it unless the destination offset has not been computed yet.
-                            if dest_offset != 0 || Some(dest) == cur.func.layout.entry_block() {
-                                offset +=
-                                    relax_branch(&mut cur, offset, dest_offset, &encinfo, isa);
-                                continue;
-                            }
+                        // This coubd be an out-of-range branch.
+                        // Relax it unless the destination offset has not been computed yet.
+                        if !range.contains(offset, dest_offset) &&
+                            (dest_offset != 0 || Some(dest) == cur.func.layout.entry_block())
+                        {
+                            offset += relax_branch(&mut cur, offset, dest_offset, &encinfo, isa);
+                            continue;
                         }
                     }
                 }

--- a/lib/cretonne/src/context.rs
+++ b/lib/cretonne/src/context.rs
@@ -132,12 +132,12 @@ impl Context {
     }
 
     /// Run the locations verifier on the function.
-    pub fn verify_locations<'a>(&self, isa: &TargetIsa) -> verifier::Result {
+    pub fn verify_locations(&self, isa: &TargetIsa) -> verifier::Result {
         verifier::verify_locations(isa, &self.func, None)
     }
 
     /// Run the locations verifier only if the `enable_verifier` setting is true.
-    pub fn verify_locations_if<'a>(&self, isa: &TargetIsa) -> CtonResult {
+    pub fn verify_locations_if(&self, isa: &TargetIsa) -> CtonResult {
         if isa.flags().enable_verifier() {
             self.verify_locations(isa).map_err(Into::into)
         } else {

--- a/lib/cretonne/src/cursor.rs
+++ b/lib/cretonne/src/cursor.rs
@@ -744,8 +744,9 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut EncCursor<'f> {
         if !self.srcloc.is_default() {
             self.func.srclocs[inst] = self.srcloc;
         }
-
         // Assign an encoding.
+        // XXX Is there a way to describe this error to the user?
+        #[cfg_attr(feature="cargo-clippy", allow(match_wild_err_arm))]
         match self.isa.encode(
             &self.func.dfg,
             &self.func.dfg[inst],

--- a/lib/cretonne/src/cursor.rs
+++ b/lib/cretonne/src/cursor.rs
@@ -746,7 +746,7 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut EncCursor<'f> {
         }
         // Assign an encoding.
         // XXX Is there a way to describe this error to the user?
-        #[cfg_attr(feature="cargo-clippy", allow(match_wild_err_arm))]
+        #[cfg_attr(feature = "cargo-clippy", allow(match_wild_err_arm))]
         match self.isa.encode(
             &self.func.dfg,
             &self.func.dfg[inst],

--- a/lib/cretonne/src/ir/dfg.rs
+++ b/lib/cretonne/src/ir/dfg.rs
@@ -362,6 +362,8 @@ impl DataFlowGraph {
     }
 
     /// Returns an object that displays `inst`.
+    // Needless lifetimes lint false positive
+    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
     pub fn display_inst<'a, I: Into<Option<&'a TargetIsa>>>(
         &'a self,
         inst: Inst,

--- a/lib/cretonne/src/ir/dfg.rs
+++ b/lib/cretonne/src/ir/dfg.rs
@@ -362,8 +362,6 @@ impl DataFlowGraph {
     }
 
     /// Returns an object that displays `inst`.
-    // Needless lifetimes lint false positive
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display_inst<'a, I: Into<Option<&'a TargetIsa>>>(
         &'a self,
         inst: Inst,

--- a/lib/cretonne/src/ir/dfg.rs
+++ b/lib/cretonne/src/ir/dfg.rs
@@ -363,7 +363,7 @@ impl DataFlowGraph {
 
     /// Returns an object that displays `inst`.
     // Needless lifetimes lint false positive
-    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display_inst<'a, I: Into<Option<&'a TargetIsa>>>(
         &'a self,
         inst: Inst,

--- a/lib/cretonne/src/ir/extfunc.rs
+++ b/lib/cretonne/src/ir/extfunc.rs
@@ -74,6 +74,8 @@ impl Signature {
     }
 
     /// Return an object that can display `self` with correct register names.
+    // Needless lifetimes lint false positive
+    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplaySignature<'a> {
         DisplaySignature(self, regs.into())
     }
@@ -187,6 +189,8 @@ impl AbiParam {
     }
 
     /// Return an object that can display `self` with correct register names.
+    // Needless lifetimes lint false positive
+    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplayAbiParam<'a> {
         DisplayAbiParam(self, regs.into())
     }

--- a/lib/cretonne/src/ir/extfunc.rs
+++ b/lib/cretonne/src/ir/extfunc.rs
@@ -74,8 +74,6 @@ impl Signature {
     }
 
     /// Return an object that can display `self` with correct register names.
-    // Needless lifetimes lint false positive
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplaySignature<'a> {
         DisplaySignature(self, regs.into())
     }
@@ -189,8 +187,6 @@ impl AbiParam {
     }
 
     /// Return an object that can display `self` with correct register names.
-    // Needless lifetimes lint false positive
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplayAbiParam<'a> {
         DisplayAbiParam(self, regs.into())
     }

--- a/lib/cretonne/src/ir/extfunc.rs
+++ b/lib/cretonne/src/ir/extfunc.rs
@@ -75,7 +75,7 @@ impl Signature {
 
     /// Return an object that can display `self` with correct register names.
     // Needless lifetimes lint false positive
-    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplaySignature<'a> {
         DisplaySignature(self, regs.into())
     }
@@ -190,7 +190,7 @@ impl AbiParam {
 
     /// Return an object that can display `self` with correct register names.
     // Needless lifetimes lint false positive
-    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplayAbiParam<'a> {
         DisplayAbiParam(self, regs.into())
     }

--- a/lib/cretonne/src/ir/extname.rs
+++ b/lib/cretonne/src/ir/extname.rs
@@ -16,7 +16,7 @@ const TESTCASE_NAME_LENGTH: usize = 16;
 /// to keep track of a sy mbol table.
 ///
 /// External names are primarily used as keys by code using Cretonne to map
-/// from a cretonne::ir::FuncRef or similar to additional associated data.
+/// from a `cretonne::ir::FuncRef` or similar to additional associated data.
 ///
 /// External names can also serve as a primitive testing and debugging tool.
 /// In particular, many `.cton` test files use function names to identify

--- a/lib/cretonne/src/ir/function.rs
+++ b/lib/cretonne/src/ir/function.rs
@@ -142,7 +142,7 @@ impl Function {
 
     /// Return an object that can display this function with correct ISA-specific annotations.
     // Needless lifetimes lint false positive
-    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, I: Into<Option<&'a TargetIsa>>>(&'a self, isa: I) -> DisplayFunction<'a> {
         DisplayFunction(self, isa.into())
     }

--- a/lib/cretonne/src/ir/function.rs
+++ b/lib/cretonne/src/ir/function.rs
@@ -141,6 +141,8 @@ impl Function {
     }
 
     /// Return an object that can display this function with correct ISA-specific annotations.
+    // Needless lifetimes lint false positive
+    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, I: Into<Option<&'a TargetIsa>>>(&'a self, isa: I) -> DisplayFunction<'a> {
         DisplayFunction(self, isa.into())
     }

--- a/lib/cretonne/src/ir/function.rs
+++ b/lib/cretonne/src/ir/function.rs
@@ -141,8 +141,6 @@ impl Function {
     }
 
     /// Return an object that can display this function with correct ISA-specific annotations.
-    // Needless lifetimes lint false positive
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, I: Into<Option<&'a TargetIsa>>>(&'a self, isa: I) -> DisplayFunction<'a> {
         DisplayFunction(self, isa.into())
     }

--- a/lib/cretonne/src/ir/layout.rs
+++ b/lib/cretonne/src/ir/layout.rs
@@ -428,7 +428,7 @@ impl Layout {
     }
 
     /// Return an iterator over all EBBs in layout order.
-    pub fn ebbs<'f>(&'f self) -> Ebbs<'f> {
+    pub fn ebbs(&self) -> Ebbs {
         Ebbs {
             layout: self,
             next: self.first_ebb,
@@ -611,7 +611,7 @@ impl Layout {
     }
 
     /// Iterate over the instructions in `ebb` in layout order.
-    pub fn ebb_insts<'f>(&'f self, ebb: Ebb) -> Insts<'f> {
+    pub fn ebb_insts(&self, ebb: Ebb) -> Insts {
         Insts {
             layout: self,
             head: self.ebbs[ebb].first_inst.into(),

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -22,7 +22,7 @@
                   assign_op_pattern,
                   unreadable_literal,
                   empty_line_after_outer_attr,
-                  // From here on i think theyre solvable:
+// From here on i think theyre solvable:
                   match_wild_err_arm,
                   useless_let_if_seq,
                   len_without_is_empty,

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -23,7 +23,6 @@
                   unreadable_literal,
                   empty_line_after_outer_attr,
                   // From here on i think theyre solvable:
-                  collapsible_if,
                   needless_lifetimes,
                   enum_variant_names,
                   match_wild_err_arm,

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -23,7 +23,6 @@
                   unreadable_literal,
                   empty_line_after_outer_attr,
                   // From here on i think theyre solvable:
-                  needless_lifetimes,
                   enum_variant_names,
                   match_wild_err_arm,
                   useless_let_if_seq,

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -6,22 +6,29 @@
 
 #![cfg_attr(feature="clippy",
             plugin(clippy(conf_file="../../clippy.toml")))]
-// Most of these are required for the generated code to pass clippy:
-#![cfg_attr(feature="cargo-clippy",
-            allow(new_without_default,
-                  new_without_default_derive,
-                  redundant_field_names,
-                  many_single_char_names,
-                  match_same_arms,
-                  should_implement_trait,
-                  identity_op,
-                  needless_borrow,
-                  cyclomatic_complexity,
-                  too_many_arguments,
-                  cast_lossless,
-                  assign_op_pattern,
-                  unreadable_literal,
-                  empty_line_after_outer_attr,
+
+#![cfg_attr(feature="cargo-clippy", allow(
+// Rustfmt 0.9.0 is at odds with this lint:
+                block_in_if_condition_stmt,
+// Generated code makes some style transgressions, but readability doesn't suffer much:
+                many_single_char_names,
+                identity_op,
+                needless_borrow,
+                cast_lossless,
+                unreadable_literal,
+                assign_op_pattern,
+                empty_line_after_outer_attr,
+// Hard to avoid in generated code:
+                cyclomatic_complexity,
+                too_many_arguments,
+// Code generator doesn't have a way to collapse identical arms:
+                match_same_arms,
+// These are relatively minor style issues, but would be easy to fix:
+                new_without_default,
+                new_without_default_derive,
+                should_implement_trait,
+                redundant_field_names,
+
 // From here on i think theyre solvable:
                   match_wild_err_arm,
                   useless_let_if_seq,

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -4,13 +4,49 @@
         trivial_numeric_casts,
         unused_extern_crates)]
 
+#![cfg_attr(feature="clippy",
+            plugin(clippy(conf_file="../../clippy.toml")))]
+// Most of these are required for the generated code to pass clippy:
+#![cfg_attr(feature="cargo-clippy",
+            allow(new_without_default,
+                  new_without_default_derive,
+                  redundant_field_names,
+                  many_single_char_names,
+                  match_same_arms,
+                  should_implement_trait,
+                  identity_op,
+                  needless_borrow,
+                  cyclomatic_complexity,
+                  too_many_arguments,
+                  cast_lossless,
+                  assign_op_pattern,
+                  unreadable_literal,
+                  empty_line_after_outer_attr,
+                  // From here on i think theyre solvable:
+                  wrong_self_convention,
+                  needless_pass_by_value,
+                  block_in_if_condition_stmt,
+                  or_fun_call,
+                  collapsible_if,
+                  needless_lifetimes,
+                  enum_variant_names,
+                  match_wild_err_arm,
+                  useless_let_if_seq,
+                  len_without_is_empty,
+                  single_match,
+                  unused_lifetimes,
+                  match_ref_pats,
+                  iter_skip_next,
+                  while_let_loop,
+                  doc_markdown))]
+
 pub use context::Context;
 pub use legalizer::legalize_function;
 pub use verifier::verify_function;
 pub use write::write_function;
 
 /// Version number of the cretonne crate.
-pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[macro_use]
 pub mod dbg;

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -23,7 +23,6 @@
                   unreadable_literal,
                   empty_line_after_outer_attr,
                   // From here on i think theyre solvable:
-                  enum_variant_names,
                   match_wild_err_arm,
                   useless_let_if_seq,
                   len_without_is_empty,

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -12,6 +12,8 @@
                 block_in_if_condition_stmt,
 // Produces only a false positive:
                 while_let_loop,
+// Produces many false positives, but did produce some valid lints, now fixed:
+                needless_lifetimes,
 // Generated code makes some style transgressions, but readability doesn't suffer much:
                 many_single_char_names,
                 identity_op,

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -28,14 +28,10 @@
                 new_without_default_derive,
                 should_implement_trait,
                 redundant_field_names,
+                useless_let_if_seq,
+                len_without_is_empty,
 
 // From here on i think theyre solvable:
-                  match_wild_err_arm,
-                  useless_let_if_seq,
-                  len_without_is_empty,
-                  single_match,
-                  unused_lifetimes,
-                  match_ref_pats,
                   iter_skip_next,
                   while_let_loop,
                   doc_markdown))]

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -10,6 +10,8 @@
 #![cfg_attr(feature="cargo-clippy", allow(
 // Rustfmt 0.9.0 is at odds with this lint:
                 block_in_if_condition_stmt,
+// Produces only a false positive:
+                while_let_loop,
 // Generated code makes some style transgressions, but readability doesn't suffer much:
                 many_single_char_names,
                 identity_op,
@@ -29,12 +31,7 @@
                 should_implement_trait,
                 redundant_field_names,
                 useless_let_if_seq,
-                len_without_is_empty,
-
-// From here on i think theyre solvable:
-                  iter_skip_next,
-                  while_let_loop,
-                  doc_markdown))]
+                len_without_is_empty))]
 
 pub use context::Context;
 pub use legalizer::legalize_function;

--- a/lib/cretonne/src/lib.rs
+++ b/lib/cretonne/src/lib.rs
@@ -23,10 +23,6 @@
                   unreadable_literal,
                   empty_line_after_outer_attr,
                   // From here on i think theyre solvable:
-                  wrong_self_convention,
-                  needless_pass_by_value,
-                  block_in_if_condition_stmt,
-                  or_fun_call,
                   collapsible_if,
                   needless_lifetimes,
                   enum_variant_names,

--- a/lib/cretonne/src/licm.rs
+++ b/lib/cretonne/src/licm.rs
@@ -150,8 +150,8 @@ fn remove_loop_invariant_instructions(
             loop_values.insert(*val);
         }
         pos.goto_top(*ebb);
+        #[cfg_attr(feature = "cargo-clippy", allow(block_in_if_condition_stmt))]
         while let Some(inst) = pos.next_inst() {
-            #![cfg_attr(feature="cargo-clippy", allow(block_in_if_condition_stmt))]
             if pos.func.dfg.has_results(inst) &&
                 pos.func.dfg.inst_args(inst).into_iter().all(|arg| {
                     !loop_values.contains(arg)

--- a/lib/cretonne/src/licm.rs
+++ b/lib/cretonne/src/licm.rs
@@ -151,6 +151,7 @@ fn remove_loop_invariant_instructions(
         }
         pos.goto_top(*ebb);
         while let Some(inst) = pos.next_inst() {
+            #![cfg_attr(feature="cargo-clippy", allow(block_in_if_condition_stmt))]
             if pos.func.dfg.has_results(inst) &&
                 pos.func.dfg.inst_args(inst).into_iter().all(|arg| {
                     !loop_values.contains(arg)

--- a/lib/cretonne/src/partition_slice.rs
+++ b/lib/cretonne/src/partition_slice.rs
@@ -6,7 +6,7 @@
 /// The order of elements is not preserved, unless the slice is already partitioned.
 ///
 /// Returns the number of elements where `p(t)` is true.
-pub fn partition_slice<'a, T: 'a, F>(s: &'a mut [T], mut p: F) -> usize
+pub fn partition_slice<T, F>(s: &mut [T], mut p: F) -> usize
 where
     F: FnMut(&T) -> bool,
 {

--- a/lib/cretonne/src/predicates.rs
+++ b/lib/cretonne/src/predicates.rs
@@ -7,7 +7,7 @@
 //! bound is implemented by all the native integer types as well as `Imm64`.
 //!
 //! Some of these predicates may be unused in certain ISA configurations, so we suppress the
-//! dead_code warning.
+//! dead code warning.
 
 /// Check that `x` is the same as `y`.
 #[allow(dead_code)]

--- a/lib/cretonne/src/preopt.rs
+++ b/lib/cretonne/src/preopt.rs
@@ -114,7 +114,7 @@ fn package_up_divrem_info(
 fn get_div_info(inst: Inst, dfg: &DataFlowGraph) -> Option<DivRemByConstInfo> {
     let idata: &InstructionData = &dfg[inst];
 
-    if let &InstructionData::BinaryImm { opcode, arg, imm } = idata {
+    if let InstructionData::BinaryImm { opcode, arg, imm } = *idata {
         let (isSigned, isRem) = match opcode {
             Opcode::UdivImm => (false, false),
             Opcode::UremImm => (false, true),
@@ -132,7 +132,7 @@ fn get_div_info(inst: Inst, dfg: &DataFlowGraph) -> Option<DivRemByConstInfo> {
     // that some previous constant propagation pass has pushed all such
     // immediates to their use points, creating BinaryImm instructions
     // instead? For now we take the conservative approach.
-    if let &InstructionData::Binary { opcode, args } = idata {
+    if let InstructionData::Binary { opcode, args } = *idata {
         let (isSigned, isRem) = match opcode {
             Opcode::Udiv => (false, false),
             Opcode::Urem => (false, true),
@@ -484,7 +484,7 @@ fn get_const(value: Value, dfg: &DataFlowGraph) -> Option<i64> {
     match dfg.value_def(value) {
         ValueDef::Result(definingInst, resultNo) => {
             let definingIData: &InstructionData = &dfg[definingInst];
-            if let &InstructionData::UnaryImm { opcode, imm } = definingIData {
+            if let InstructionData::UnaryImm { opcode, imm } = *definingIData {
                 if opcode == Opcode::Iconst && resultNo == 0 {
                     return Some(imm.into());
                 }

--- a/lib/cretonne/src/print_errors.rs
+++ b/lib/cretonne/src/print_errors.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 pub fn pretty_verifier_error(
     func: &ir::Function,
     isa: Option<&TargetIsa>,
-    err: verifier::Error,
+    err: &verifier::Error,
 ) -> String {
     let mut msg = err.to_string();
     match err.location {
@@ -26,7 +26,7 @@ pub fn pretty_verifier_error(
 /// Pretty-print a Cretonne error.
 pub fn pretty_error(func: &ir::Function, isa: Option<&TargetIsa>, err: CtonError) -> String {
     if let CtonError::Verifier(e) = err {
-        pretty_verifier_error(func, isa, e)
+        pretty_verifier_error(func, isa, &e)
     } else {
         err.to_string()
     }

--- a/lib/cretonne/src/ref_slice.rs
+++ b/lib/cretonne/src/ref_slice.rs
@@ -1,6 +1,6 @@
 //! Functions for converting a reference into a singleton slice.
 //!
-//! See also the ref_slice crate on crates.io.
+//! See also the [`ref_slice` crate](https://crates.io/crates/ref_slice).
 //!
 //! We define the functions here to avoid external dependencies, and to ensure that they are
 //! inlined in this crate.

--- a/lib/cretonne/src/regalloc/allocatable_set.rs
+++ b/lib/cretonne/src/regalloc/allocatable_set.rs
@@ -198,7 +198,7 @@ impl<'a> fmt::Display for DisplayAllocatableSet<'a> {
                                 bank.names
                                     .get(offset as usize)
                                     .and_then(|name| name.chars().skip(1).next())
-                                    .unwrap_or(
+                                    .unwrap_or_else( ||
                                         char::from_digit(u32::from(offset % 10), 10).unwrap(),
                                     )
                             )?;

--- a/lib/cretonne/src/regalloc/allocatable_set.rs
+++ b/lib/cretonne/src/regalloc/allocatable_set.rs
@@ -197,7 +197,7 @@ impl<'a> fmt::Display for DisplayAllocatableSet<'a> {
                                 "{}",
                                 bank.names
                                     .get(offset as usize)
-                                    .and_then(|name| name.chars().skip(1).next())
+                                    .and_then(|name| name.chars().nth(1))
                                     .unwrap_or_else(
                                         || char::from_digit(u32::from(offset % 10), 10).unwrap(),
                                     )

--- a/lib/cretonne/src/regalloc/allocatable_set.rs
+++ b/lib/cretonne/src/regalloc/allocatable_set.rs
@@ -198,8 +198,8 @@ impl<'a> fmt::Display for DisplayAllocatableSet<'a> {
                                 bank.names
                                     .get(offset as usize)
                                     .and_then(|name| name.chars().skip(1).next())
-                                    .unwrap_or_else( ||
-                                        char::from_digit(u32::from(offset % 10), 10).unwrap(),
+                                    .unwrap_or_else(
+                                        || char::from_digit(u32::from(offset % 10), 10).unwrap(),
                                     )
                             )?;
                         }

--- a/lib/cretonne/src/regalloc/diversion.rs
+++ b/lib/cretonne/src/regalloc/diversion.rs
@@ -161,7 +161,7 @@ impl RegDiversions {
 
     /// Return an object that can display the diversions.
     // Needless lifetimes lint false positive
-    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplayDiversions<'a> {
         DisplayDiversions(self, regs.into())
     }

--- a/lib/cretonne/src/regalloc/diversion.rs
+++ b/lib/cretonne/src/regalloc/diversion.rs
@@ -160,8 +160,6 @@ impl RegDiversions {
     }
 
     /// Return an object that can display the diversions.
-    // Needless lifetimes lint false positive
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplayDiversions<'a> {
         DisplayDiversions(self, regs.into())
     }

--- a/lib/cretonne/src/regalloc/diversion.rs
+++ b/lib/cretonne/src/regalloc/diversion.rs
@@ -160,6 +160,8 @@ impl RegDiversions {
     }
 
     /// Return an object that can display the diversions.
+    // Needless lifetimes lint false positive
+    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&'a self, regs: R) -> DisplayDiversions<'a> {
         DisplayDiversions(self, regs.into())
     }

--- a/lib/cretonne/src/regalloc/reload.rs
+++ b/lib/cretonne/src/regalloc/reload.rs
@@ -306,14 +306,12 @@ impl<'a> Context<'a> {
         let args = self.cur.func.dfg.inst_args(inst);
 
         for (argidx, (op, &arg)) in constraints.ins.iter().zip(args).enumerate() {
-            if op.kind != ConstraintKind::Stack {
-                if self.liveness[arg].affinity.is_stack() {
-                    self.candidates.push(ReloadCandidate {
-                        argidx,
-                        value: arg,
-                        regclass: op.regclass,
-                    })
-                }
+            if op.kind != ConstraintKind::Stack && self.liveness[arg].affinity.is_stack() {
+                self.candidates.push(ReloadCandidate {
+                    argidx,
+                    value: arg,
+                    regclass: op.regclass,
+                })
             }
         }
 

--- a/lib/cretonne/src/regalloc/solver.rs
+++ b/lib/cretonne/src/regalloc/solver.rs
@@ -299,6 +299,7 @@ impl Move {
     }
 
     /// Get the "from" register and register class, if possible.
+    #[cfg_attr(feature="cargo-clippy", allow(wrong_self_convention))]
     fn from_reg(&self) -> Option<(RegClass, RegUnit)> {
         match *self {
             Move::Reg { rc, from, .. } |

--- a/lib/cretonne/src/regalloc/solver.rs
+++ b/lib/cretonne/src/regalloc/solver.rs
@@ -299,7 +299,7 @@ impl Move {
     }
 
     /// Get the "from" register and register class, if possible.
-    #[cfg_attr(feature="cargo-clippy", allow(wrong_self_convention))]
+    #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
     fn from_reg(&self) -> Option<(RegClass, RegUnit)> {
         match *self {
             Move::Reg { rc, from, .. } |

--- a/lib/cretonne/src/regalloc/virtregs.rs
+++ b/lib/cretonne/src/regalloc/virtregs.rs
@@ -373,7 +373,7 @@ impl VirtRegs {
             let vreg = self.get(leader).unwrap_or_else(|| {
                 // Allocate a vreg for `leader`, but leave it empty.
                 let vr = self.alloc();
-                if let &mut Some(ref mut vec) = &mut new_vregs {
+                if let Some(ref mut vec) = new_vregs {
                     vec.push(vr);
                 }
                 self.value_vregs[leader] = vr.into();

--- a/lib/cretonne/src/regalloc/virtregs.rs
+++ b/lib/cretonne/src/regalloc/virtregs.rs
@@ -101,8 +101,10 @@ impl VirtRegs {
     where
         'a: 'b,
     {
-        self.get(*value).map(|vr| self.values(vr)).unwrap_or(
-            ref_slice(value),
+        self.get(*value).map(|vr| self.values(vr)).unwrap_or_else(
+            || {
+                ref_slice(value)
+            },
         )
     }
 

--- a/lib/cretonne/src/scoped_hash_map.rs
+++ b/lib/cretonne/src/scoped_hash_map.rs
@@ -1,4 +1,4 @@
-//! ScopedHashMap
+//! `ScopedHashMap`
 //!
 //! This module defines a struct `ScopedHashMap<K, V>` which defines a `HashMap`-like
 //! container that has a concept of scopes that can be entered and exited, such that

--- a/lib/cretonne/src/timing.rs
+++ b/lib/cretonne/src/timing.rs
@@ -204,7 +204,7 @@ mod details {
     }
 
     /// Add `timings` to the accumulated timings for the current thread.
-    pub fn add_to_current(times: PassTimes) {
+    pub fn add_to_current(times: &PassTimes) {
         PASS_TIME.with(|rc| for (a, b) in rc.borrow_mut().pass.iter_mut().zip(
             &times.pass,
         )

--- a/lib/cretonne/src/timing.rs
+++ b/lib/cretonne/src/timing.rs
@@ -11,7 +11,7 @@ pub use self::details::{TimingToken, PassTimes, take_current, add_to_current};
 //
 // This macro defines:
 //
-// - A C-style enum containing all the pass names and a `NoPass` variant.
+// - A C-style enum containing all the pass names and a `None` variant.
 // - A usize constant with the number of defined passes.
 // - A const array of pass descriptions.
 // - A public function per pass used to start the timing of that pass.
@@ -21,9 +21,9 @@ macro_rules! define_passes {
     } => {
         #[allow(non_camel_case_types)]
         #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-        enum $enum { $($pass,)+ NoPass }
+        enum $enum { $($pass,)+ None}
 
-        const $num_passes: usize = $enum::NoPass as usize;
+        const $num_passes: usize = $enum::None as usize;
 
         const $descriptions: [&str; $num_passes] = [ $($desc),+ ];
 
@@ -164,7 +164,7 @@ mod details {
 
     /// Information about passes in a single thread.
     thread_local!{
-        static CURRENT_PASS: Cell<Pass> = Cell::new(Pass::NoPass);
+        static CURRENT_PASS: Cell<Pass> = Cell::new(Pass::None);
         static PASS_TIME: RefCell<PassTimes> = RefCell::new(Default::default());
     }
 
@@ -221,7 +221,7 @@ mod test {
 
     #[test]
     fn display() {
-        assert_eq!(Pass::NoPass.to_string(), "<no pass>");
+        assert_eq!(Pass::None.to_string(), "<no pass>");
         assert_eq!(Pass::regalloc.to_string(), "Register allocation");
     }
 }

--- a/lib/cretonne/src/verifier/liveness.rs
+++ b/lib/cretonne/src/verifier/liveness.rs
@@ -86,16 +86,14 @@ impl<'a> LivenessVerifier<'a> {
                                 self.isa.encoding_info().display(encoding)
                             );
                         }
-                    } else {
+                    } else if !lr.affinity.is_none() {
                         // A non-encoded instruction can only define ghost values.
-                        if !lr.affinity.is_none() {
-                            return err!(
-                                inst,
-                                "{} is a real {} value defined by a ghost instruction",
-                                val,
-                                lr.affinity.display(&self.isa.register_info())
-                            );
-                        }
+                        return err!(
+                            inst,
+                            "{} is a real {} value defined by a ghost instruction",
+                            val,
+                            lr.affinity.display(&self.isa.register_info())
+                        );
                     }
                 }
 
@@ -109,16 +107,14 @@ impl<'a> LivenessVerifier<'a> {
                         return err!(inst, "{} is not live at this use", val);
                     }
 
-                    if encoding.is_legal() {
-                        // A legal instruction is not allowed to depend on ghost values.
-                        if lr.affinity.is_none() {
-                            return err!(
-                                inst,
-                                "{} is a ghost value used by a real [{}] instruction",
-                                val,
-                                self.isa.encoding_info().display(encoding)
-                            );
-                        }
+                    // A legal instruction is not allowed to depend on ghost values.
+                    if encoding.is_legal() && lr.affinity.is_none() {
+                        return err!(
+                            inst,
+                            "{} is a ghost value used by a real [{}] instruction",
+                            val,
+                            self.isa.encoding_info().display(encoding)
+                        );
                     }
                 }
             }

--- a/lib/cretonne/src/verifier/mod.rs
+++ b/lib/cretonne/src/verifier/mod.rs
@@ -34,7 +34,7 @@
 //!   For polymorphic opcodes, determine the controlling type variable first.
 //! - Branches and jumps must pass arguments to destination EBBs that match the
 //!   expected types exactly. The number of arguments must match.
-//! - All EBBs in a jump_table must take no arguments.
+//! - All EBBs in a jump table must take no arguments.
 //! - Function calls are type checked against their signature.
 //! - The entry block must take arguments that match the signature of the current
 //!   function.

--- a/lib/filetests/src/concurrent.rs
+++ b/lib/filetests/src/concurrent.rs
@@ -70,7 +70,7 @@ impl ConcurrentRunner {
         assert!(self.request_tx.is_none(), "must shutdown before join");
         for h in self.handles.drain(..) {
             match h.join() {
-                Ok(t) => timing::add_to_current(t),
+                Ok(t) => timing::add_to_current(&t),
                 Err(e) => println!("worker panicked: {:?}", e),
             }
         }

--- a/lib/filetests/src/lib.rs
+++ b/lib/filetests/src/lib.rs
@@ -3,6 +3,11 @@
 //! This crate contains the main test driver as well as implementations of the
 //! available filetest commands.
 
+#![cfg_attr(feature="cargo-clippy", allow(
+        type_complexity,
+// Rustfmt 0.9.0 is at odds with this lint:
+        block_in_if_condition_stmt))]
+
 #[macro_use(dbg)]
 extern crate cretonne;
 extern crate cton_reader;
@@ -44,7 +49,7 @@ type TestResult = Result<time::Duration, String>;
 /// Directories are scanned recursively for test cases ending in `.cton`. These test cases are
 /// executed on background threads.
 ///
-pub fn run(verbose: bool, files: Vec<String>) -> TestResult {
+pub fn run(verbose: bool, files: &[String]) -> TestResult {
     let mut runner = TestRunner::new(verbose);
 
     for path in files.iter().map(Path::new) {

--- a/lib/filetests/src/runner.rs
+++ b/lib/filetests/src/runner.rs
@@ -45,7 +45,7 @@ impl Display for QueueEntry {
                     f,
                     "{}.{:03} {}",
                     dur.as_secs(),
-                    dur.subsec_nanos() / 1000000,
+                    dur.subsec_nanos() / 1_000_000,
                     p
                 )
             }
@@ -135,7 +135,7 @@ impl TestRunner {
                     // This lets us skip spurious extensionless files without statting everything
                     // needlessly.
                     if !dir.is_file() {
-                        self.path_error(dir, err);
+                        self.path_error(&dir, &err);
                     }
                 }
                 Ok(entries) => {
@@ -149,7 +149,7 @@ impl TestRunner {
                                 // libstd/sys/unix/fs.rs seems to suggest that breaking now would
                                 // be a good idea, or the iterator could keep returning the same
                                 // error forever.
-                                self.path_error(dir, err);
+                                self.path_error(&dir, &err);
                                 break;
                             }
                             Ok(entry) => {
@@ -172,7 +172,7 @@ impl TestRunner {
     }
 
     /// Report an error related to a path.
-    fn path_error<E: Error>(&mut self, path: PathBuf, err: E) {
+    fn path_error<E: Error>(&mut self, path: &PathBuf, err: &E) {
         self.errors += 1;
         println!("{}: {}", path.to_string_lossy(), err);
     }

--- a/lib/filetests/src/runone.rs
+++ b/lib/filetests/src/runone.rs
@@ -132,7 +132,7 @@ fn run_one_test<'a>(
     if !context.verified && test.needs_verifier() {
         verify_function(&func, context.flags_or_isa()).map_err(
             |e| {
-                pretty_verifier_error(&func, isa, e)
+                pretty_verifier_error(&func, isa, &e)
             },
         )?;
         context.verified = true;

--- a/lib/filetests/src/subtest.rs
+++ b/lib/filetests/src/subtest.rs
@@ -1,4 +1,4 @@
-//! SubTest trait.
+//! `SubTest` trait.
 
 use std::result;
 use std::borrow::Cow;

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -548,6 +548,8 @@ where
     /// Returns a displayable object for the function as it is.
     ///
     /// Useful for debug purposes. Use it with `None` for standard printing.
+    // Clippy thinks the lifetime that follows is needless, but rustc needs it
+    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'b, I: Into<Option<&'b TargetIsa>>>(&'b self, isa: I) -> DisplayFunction {
         self.func.display(isa)
     }

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -439,15 +439,15 @@ where
     pub fn finalize(&mut self) {
         // Check that all the `Ebb`s are filled and sealed.
         debug_assert!(
-            self.func_ctx.ebbs.keys().all(|ebb|
+            self.func_ctx.ebbs.keys().all(|ebb| {
                 self.func_ctx.ebbs[ebb].pristine || self.func_ctx.ssa.is_sealed(ebb)
-            ),
+            }),
             "all blocks should be sealed before dropping a FunctionBuilder"
         );
         debug_assert!(
-            self.func_ctx.ebbs.keys().all(|ebb|
+            self.func_ctx.ebbs.keys().all(|ebb| {
                 self.func_ctx.ebbs[ebb].pristine || self.func_ctx.ebbs[ebb].filled
-            ),
+            }),
             "all blocks should be filled before dropping a FunctionBuilder"
         );
 
@@ -549,7 +549,7 @@ where
     ///
     /// Useful for debug purposes. Use it with `None` for standard printing.
     // Clippy thinks the lifetime that follows is needless, but rustc needs it
-    #[cfg_attr(feature="cargo-clippy", allow(needless_lifetimes))]
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_lifetimes))]
     pub fn display<'b, I: Into<Option<&'b TargetIsa>>>(&'b self, isa: I) -> DisplayFunction {
         self.func.display(isa)
     }

--- a/lib/frontend/src/frontend.rs
+++ b/lib/frontend/src/frontend.rs
@@ -400,7 +400,7 @@ where
     ///
     /// This can be used to insert SSA code that doesn't need to access locals and that doesn't
     /// need to know about `FunctionBuilder` at all.
-    pub fn cursor<'f>(&'f mut self) -> FuncCursor<'f> {
+    pub fn cursor(&mut self) -> FuncCursor {
         self.ensure_inserted_ebb();
         FuncCursor::new(self.func)
             .with_srcloc(self.srcloc)
@@ -439,15 +439,15 @@ where
     pub fn finalize(&mut self) {
         // Check that all the `Ebb`s are filled and sealed.
         debug_assert!(
-            self.func_ctx.ebbs.keys().all(|ebb| {
+            self.func_ctx.ebbs.keys().all(|ebb|
                 self.func_ctx.ebbs[ebb].pristine || self.func_ctx.ssa.is_sealed(ebb)
-            }),
+            ),
             "all blocks should be sealed before dropping a FunctionBuilder"
         );
         debug_assert!(
-            self.func_ctx.ebbs.keys().all(|ebb| {
+            self.func_ctx.ebbs.keys().all(|ebb|
                 self.func_ctx.ebbs[ebb].pristine || self.func_ctx.ebbs[ebb].filled
-            }),
+            ),
             "all blocks should be filled before dropping a FunctionBuilder"
         );
 

--- a/lib/frontend/src/lib.rs
+++ b/lib/frontend/src/lib.rs
@@ -131,6 +131,9 @@
         trivial_numeric_casts,
         unused_extern_crates)]
 
+#![cfg_attr(feature="cargo-clippy",
+            allow(new_without_default, redundant_field_names))]
+
 extern crate cretonne;
 
 pub use frontend::{FunctionBuilderContext, FunctionBuilder};

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -53,7 +53,7 @@ pub struct LocatedToken<'a> {
 }
 
 /// Wrap up a `Token` with the given location.
-fn token<'a>(token: Token<'a>, loc: Location) -> Result<LocatedToken<'a>, LocatedError> {
+fn token(token: Token, loc: Location) -> Result<LocatedToken, LocatedError> {
     Ok(LocatedToken {
         token,
         location: loc,

--- a/lib/reader/src/lib.rs
+++ b/lib/reader/src/lib.rs
@@ -1,6 +1,6 @@
 //! Cretonne file reader library.
 //!
-//! The cton_reader library supports reading .cton files. This functionality is needed for testing
+//! The `cton_reader` library supports reading .cton files. This functionality is needed for testing
 //! Cretonne, but is not essential for a JIT compiler.
 
 #![deny(missing_docs,

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -280,7 +280,7 @@ impl<'a> Parser<'a> {
         // clippy says self.lookahead is immutable so this loop is either infinite or never
         // running. I don't think this is true - self.lookahead is mutated in the loop body - so
         // maybe this is a clippy bug? Either way, disable clippy for this.
-        #[cfg_attr(feature="cargo-clippy", allow(while_immutable_condition))]
+        #[cfg_attr(feature = "cargo-clippy", allow(while_immutable_condition))]
         while self.lookahead == None {
             match self.lex.next() {
                 Some(Ok(lexer::LocatedToken { token, location })) => {

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -37,7 +37,7 @@ pub fn parse_functions(text: &str) -> Result<Vec<Function>> {
 /// Parse the entire `text` as a test case file.
 ///
 /// The returned `TestFile` contains direct references to substrings of `text`.
-pub fn parse_test<'a>(text: &'a str) -> Result<TestFile<'a>> {
+pub fn parse_test(text: &str) -> Result<TestFile> {
     let _tt = timing::parse_text();
     let mut parser = Parser::new(text);
     // Gather the preamble comments.
@@ -957,7 +957,7 @@ impl<'a> Parser<'a> {
                         isa.register_info()
                             .parse_regunit(name)
                             .map(ArgumentLoc::Reg)
-                            .ok_or(self.error("invalid register name"))
+                            .ok_or_else(|| self.error("invalid register name"))
                     } else {
                         err!(self.loc, "argument location requires exactly one isa")
                     }
@@ -1392,12 +1392,12 @@ impl<'a> Parser<'a> {
             match self.token() {
                 Some(Token::Arrow) => {
                     self.consume();
-                    self.parse_value_alias(results, ctx)?;
+                    self.parse_value_alias(&results, ctx)?;
                 }
                 Some(Token::Equal) => {
                     self.consume();
                     self.parse_instruction(
-                        results,
+                        &results,
                         srcloc,
                         encoding,
                         result_locations,
@@ -1408,7 +1408,7 @@ impl<'a> Parser<'a> {
                 _ if !results.is_empty() => return err!(self.loc, "expected -> or ="),
                 _ => {
                     self.parse_instruction(
-                        results,
+                        &results,
                         srcloc,
                         encoding,
                         result_locations,
@@ -1512,7 +1512,7 @@ impl<'a> Parser<'a> {
                     isa.register_info()
                         .parse_regunit(name)
                         .map(ValueLoc::Reg)
-                        .ok_or(self.error("invalid register value location"))
+                        .ok_or_else(|| self.error("invalid register value location"))
                 } else {
                     err!(self.loc, "value location requires exactly one isa")
                 }
@@ -1601,7 +1601,7 @@ impl<'a> Parser<'a> {
     //
     // value_alias ::= [inst-results] "->" Value(v)
     //
-    fn parse_value_alias(&mut self, results: Vec<Value>, ctx: &mut Context) -> Result<()> {
+    fn parse_value_alias(&mut self, results: &[Value], ctx: &mut Context) -> Result<()> {
         if results.len() != 1 {
             return err!(self.loc, "wrong number of aliases");
         }
@@ -1621,7 +1621,7 @@ impl<'a> Parser<'a> {
     //
     fn parse_instruction(
         &mut self,
-        results: Vec<Value>,
+        results: &[Value],
         srcloc: ir::SourceLoc,
         encoding: Option<Encoding>,
         result_locations: Option<Vec<ValueLoc>>,
@@ -1629,7 +1629,7 @@ impl<'a> Parser<'a> {
         ebb: Ebb,
     ) -> Result<()> {
         // Define the result values.
-        for val in &results {
+        for val in results {
             ctx.map.def_value(*val, &self.loc)?;
         }
 
@@ -1674,7 +1674,7 @@ impl<'a> Parser<'a> {
         let num_results = ctx.function.dfg.make_inst_results_for_parser(
             inst,
             ctrl_typevar,
-            &results,
+            results,
         );
         ctx.function.layout.append_inst(inst, ebb);
         ctx.map.def_entity(inst.into(), &opcode_loc).expect(
@@ -1784,11 +1784,9 @@ impl<'a> Parser<'a> {
                     opcode
                 );
             }
-        } else {
-            // Treat it as a syntax error to speficy a typevar on a non-polymorphic opcode.
-            if ctrl_type != VOID {
+        // Treat it as a syntax error to speficy a typevar on a non-polymorphic opcode.
+        } else if ctrl_type != VOID {
                 return err!(self.loc, "{} does not take a typevar", opcode);
-            }
         }
 
         Ok(ctrl_type)

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -277,6 +277,10 @@ impl<'a> Parser<'a> {
 
     // Get the current lookahead token, after making sure there is one.
     fn token(&mut self) -> Option<Token<'a>> {
+        // clippy says self.lookahead is immutable so this loop is either infinite or never
+        // running. I don't think this is true - self.lookahead is mutated in the loop body - so
+        // maybe this is a clippy bug? Either way, disable clippy for this.
+        #[cfg_attr(feature="cargo-clippy", allow(while_immutable_condition))]
         while self.lookahead == None {
             match self.lex.next() {
                 Some(Ok(lexer::LocatedToken { token, location })) => {
@@ -1786,7 +1790,7 @@ impl<'a> Parser<'a> {
             }
         // Treat it as a syntax error to speficy a typevar on a non-polymorphic opcode.
         } else if ctrl_type != VOID {
-                return err!(self.loc, "{} does not take a typevar", opcode);
+            return err!(self.loc, "{} does not take a typevar", opcode);
         }
 
         Ok(ctrl_type)

--- a/lib/reader/src/sourcemap.rs
+++ b/lib/reader/src/sourcemap.rs
@@ -13,7 +13,7 @@ use lexer::split_entity_name;
 use std::collections::HashMap;
 
 /// Mapping from entity names to source locations.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SourceMap {
     // Store locations for entities, including instructions.
     locations: HashMap<AnyEntity, Location>,

--- a/lib/wasm/src/environ/dummy.rs
+++ b/lib/wasm/src/environ/dummy.rs
@@ -121,7 +121,7 @@ impl DummyEnvironment {
     }
 }
 
-/// The FuncEnvironment implementation for use by the `DummyEnvironment`.
+/// The `FuncEnvironment` implementation for use by the `DummyEnvironment`.
 pub struct DummyFuncEnvironment<'dummy_environment> {
     pub mod_info: &'dummy_environment DummyModuleInfo,
 }

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -14,6 +14,8 @@
         unused_extern_crates)]
 #![cfg_attr(feature="clippy",
             plugin(clippy(conf_file="../../clippy.toml")))]
+#![cfg_attr(feature="cargo-clippy",
+            allow(new_without_default, redundant_field_names))]
 
 extern crate wasmparser;
 extern crate cton_frontend;

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -12,6 +12,8 @@
 #![deny(missing_docs,
         trivial_numeric_casts,
         unused_extern_crates)]
+#![cfg_attr(feature="clippy",
+            plugin(clippy(conf_file="../../clippy.toml")))]
 
 extern crate wasmparser;
 extern crate cton_frontend;

--- a/lib/wasm/tests/wasm_testsuite.rs
+++ b/lib/wasm/tests/wasm_testsuite.rs
@@ -25,7 +25,7 @@ fn testsuite() {
             // Ignore files starting with `.`, which could be editor temporary files
             if let Some(stem) = p.path().file_stem() {
                 if let Some(stemstr) = stem.to_str() {
-                    return !stemstr.starts_with(".");
+                    return !stemstr.starts_with('.');
                 }
             }
             false
@@ -35,7 +35,7 @@ fn testsuite() {
     let flags = Flags::new(&settings::builder());
     for path in paths {
         let path = path.path();
-        handle_module(path, &flags);
+        handle_module(&path, &flags);
     }
 }
 
@@ -44,7 +44,7 @@ fn return_at_end() {
     let mut flag_builder = settings::builder();
     flag_builder.enable("return_at_end").unwrap();
     let flags = Flags::new(&flag_builder);
-    handle_module(PathBuf::from("../../wasmtests/return_at_end.wat"), &flags);
+    handle_module(&PathBuf::from("../../wasmtests/return_at_end.wat"), &flags);
 }
 
 fn read_wasm_file(path: PathBuf) -> Result<Vec<u8>, io::Error> {
@@ -54,7 +54,7 @@ fn read_wasm_file(path: PathBuf) -> Result<Vec<u8>, io::Error> {
     Ok(buf)
 }
 
-fn handle_module(path: PathBuf, flags: &Flags) {
+fn handle_module(path: &PathBuf, flags: &Flags) {
     let data = match path.extension() {
         None => {
             panic!("the file extension is not wasm or wat");

--- a/lib/wasm/tests/wasm_testsuite.rs
+++ b/lib/wasm/tests/wasm_testsuite.rs
@@ -103,7 +103,7 @@ fn handle_module(path: &PathBuf, flags: &Flags) {
     translate_module(&data, &mut dummy_environ).unwrap();
     for func in &dummy_environ.info.function_bodies {
         verifier::verify_function(func, flags)
-            .map_err(|err| panic!(pretty_verifier_error(func, None, err)))
+            .map_err(|err| panic!(pretty_verifier_error(func, None, &err)))
             .unwrap();
     }
 }

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -7,7 +7,7 @@ use cton_reader::parse_functions;
 use CommandResult;
 use utils::read_to_string;
 
-pub fn run(files: Vec<String>) -> CommandResult {
+pub fn run(files: &[String]) -> CommandResult {
     for (i, f) in files.into_iter().enumerate() {
         if i != 0 {
             println!();
@@ -17,7 +17,7 @@ pub fn run(files: Vec<String>) -> CommandResult {
     Ok(())
 }
 
-fn cat_one(filename: String) -> CommandResult {
+fn cat_one(filename: &str) -> CommandResult {
     let buffer = read_to_string(&filename).map_err(
         |e| format!("{}: {}", filename, e),
     )?;

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -49,8 +49,8 @@ impl binemit::RelocSink for PrintRelocs {
 pub fn run(
     files: Vec<String>,
     flag_print: bool,
-    flag_set: Vec<String>,
-    flag_isa: String,
+    flag_set: &[String],
+    flag_isa: &str,
 ) -> Result<(), String> {
     let parsed = parse_sets_and_isa(flag_set, flag_isa)?;
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -57,15 +57,15 @@ pub fn run(
     for filename in files {
         let path = Path::new(&filename);
         let name = String::from(path.as_os_str().to_string_lossy());
-        handle_module(flag_print, path.to_path_buf(), name, parsed.as_fisa())?;
+        handle_module(flag_print, &path.to_path_buf(), &name, parsed.as_fisa())?;
     }
     Ok(())
 }
 
 fn handle_module(
     flag_print: bool,
-    path: PathBuf,
-    name: String,
+    path: &PathBuf,
+    name: &str,
     fisa: FlagsOrIsa,
 ) -> Result<(), String> {
     let buffer = read_to_string(&path).map_err(

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -94,7 +94,7 @@ fn cton_util() -> CommandResult {
     } else if args.cmd_print_cfg {
         print_cfg::run(args.arg_file)
     } else if args.cmd_compile {
-        compile::run(args.arg_file, args.flag_print, args.flag_set, args.flag_isa)
+        compile::run(args.arg_file, args.flag_print, &args.flag_set, &args.flag_isa)
     } else if args.cmd_wasm {
         wasm::run(
             args.arg_file,
@@ -102,8 +102,8 @@ fn cton_util() -> CommandResult {
             args.flag_just_decode,
             args.flag_check_translation,
             args.flag_print,
-            args.flag_set,
-            args.flag_isa,
+            &args.flag_set,
+            &args.flag_isa,
             args.flag_print_size,
         )
     } else {

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -94,7 +94,12 @@ fn cton_util() -> CommandResult {
     } else if args.cmd_print_cfg {
         print_cfg::run(&args.arg_file)
     } else if args.cmd_compile {
-        compile::run(args.arg_file, args.flag_print, &args.flag_set, &args.flag_isa)
+        compile::run(
+            args.arg_file,
+            args.flag_print,
+            &args.flag_set,
+            &args.flag_isa,
+        )
     } else if args.cmd_wasm {
         wasm::run(
             args.arg_file,

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -88,11 +88,11 @@ fn cton_util() -> CommandResult {
     let result = if args.cmd_test {
         cton_filetests::run(args.flag_verbose, args.arg_file).map(|_time| ())
     } else if args.cmd_cat {
-        cat::run(args.arg_file)
+        cat::run(&args.arg_file)
     } else if args.cmd_filecheck {
-        rsfilecheck::run(args.arg_file, args.flag_verbose)
+        rsfilecheck::run(&args.arg_file, args.flag_verbose)
     } else if args.cmd_print_cfg {
-        print_cfg::run(args.arg_file)
+        print_cfg::run(&args.arg_file)
     } else if args.cmd_compile {
         compile::run(args.arg_file, args.flag_print, &args.flag_set, &args.flag_isa)
     } else if args.cmd_wasm {

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -86,7 +86,7 @@ fn cton_util() -> CommandResult {
 
     // Find the sub-command to execute.
     let result = if args.cmd_test {
-        cton_filetests::run(args.flag_verbose, args.arg_file).map(|_time| ())
+        cton_filetests::run(args.flag_verbose, &args.arg_file).map(|_time| ())
     } else if args.cmd_cat {
         cat::run(&args.arg_file)
     } else if args.cmd_filecheck {

--- a/src/print_cfg.rs
+++ b/src/print_cfg.rs
@@ -8,7 +8,7 @@ use cretonne::cfg_printer::CFGPrinter;
 use cton_reader::parse_functions;
 use utils::read_to_string;
 
-pub fn run(files: Vec<String>) -> CommandResult {
+pub fn run(files: &[String]) -> CommandResult {
     for (i, f) in files.into_iter().enumerate() {
         if i != 0 {
             println!();
@@ -18,8 +18,8 @@ pub fn run(files: Vec<String>) -> CommandResult {
     Ok(())
 }
 
-fn print_cfg(filename: String) -> CommandResult {
-    let buffer = read_to_string(&filename).map_err(
+fn print_cfg(filename: &str) -> CommandResult {
+    let buffer = read_to_string(filename).map_err(
         |e| format!("{}: {}", filename, e),
     )?;
     let items = parse_functions(&buffer).map_err(

--- a/src/rsfilecheck.rs
+++ b/src/rsfilecheck.rs
@@ -7,7 +7,7 @@ use utils::read_to_string;
 use filecheck::{CheckerBuilder, Checker, NO_VARIABLES};
 use std::io::{self, Read};
 
-pub fn run(files: Vec<String>, verbose: bool) -> CommandResult {
+pub fn run(files: &[String], verbose: bool) -> CommandResult {
     if files.is_empty() {
         return Err("No check files".to_string());
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,8 +42,8 @@ impl OwnedFlagsOrIsa {
 
 /// Parse "set" and "isa" commands.
 pub fn parse_sets_and_isa(
-    flag_set: Vec<String>,
-    flag_isa: String,
+    flag_set: &[String],
+    flag_isa: &str,
 ) -> Result<OwnedFlagsOrIsa, String> {
     let mut flag_builder = settings::builder();
     parse_options(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,10 +41,7 @@ impl OwnedFlagsOrIsa {
 }
 
 /// Parse "set" and "isa" commands.
-pub fn parse_sets_and_isa(
-    flag_set: &[String],
-    flag_isa: &str,
-) -> Result<OwnedFlagsOrIsa, String> {
+pub fn parse_sets_and_isa(flag_set: &[String], flag_isa: &str) -> Result<OwnedFlagsOrIsa, String> {
     let mut flag_builder = settings::builder();
     parse_options(
         flag_set.iter().map(|x| x.as_str()),

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -38,8 +38,8 @@ pub fn run(
     flag_just_decode: bool,
     flag_check_translation: bool,
     flag_print: bool,
-    flag_set: Vec<String>,
-    flag_isa: String,
+    flag_set: &[String],
+    flag_isa: &str,
     flag_print_size: bool,
 ) -> Result<(), String> {
     let parsed = parse_sets_and_isa(flag_set, flag_isa)?;
@@ -155,27 +155,25 @@ fn handle_module(
             context.verify(fisa).map_err(|err| {
                 pretty_verifier_error(&context.func, fisa.isa, err)
             })?;
-        } else {
-            if let Some(isa) = fisa.isa {
-                let compiled_size = context.compile(isa).map_err(|err| {
-                    pretty_error(&context.func, fisa.isa, err)
-                })?;
-                if flag_print_size {
-                    println!(
-                        "Function #{} code size: {} bytes",
-                        func_index,
-                        compiled_size
-                    );
-                    total_module_code_size += compiled_size;
-                    println!(
-                        "Function #{} bytecode size: {} bytes",
-                        func_index,
-                        dummy_environ.func_bytecode_sizes[func_index]
-                    );
-                }
-            } else {
-                return Err(String::from("compilation requires a target isa"));
+        } else if let Some(isa) = fisa.isa {
+            let compiled_size = context.compile(isa).map_err(|err| {
+                pretty_error(&context.func, fisa.isa, err)
+            })?;
+            if flag_print_size {
+                println!(
+                    "Function #{} code size: {} bytes",
+                    func_index,
+                    compiled_size
+                );
+                total_module_code_size += compiled_size;
+                println!(
+                    "Function #{} bytecode size: {} bytes",
+                    func_index,
+                    dummy_environ.func_bytecode_sizes[func_index]
+                );
             }
+        } else {
+            return Err(String::from("compilation requires a target isa"));
         }
         if flag_print {
             vprintln!(flag_verbose, "");

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,7 @@
 //! CLI tool to use the functions provided by the [cretonne-wasm](../cton_wasm/index.html) crate.
 //!
 //! Reads Wasm binary files, translates the functions' code to Cretonne IL.
+#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments, cyclomatic_complexity))]
 
 use cton_wasm::{translate_module, DummyEnvironment, ModuleEnvironment};
 use std::path::PathBuf;
@@ -53,8 +54,8 @@ pub fn run(
             flag_check_translation,
             flag_print,
             flag_print_size,
-            path.to_path_buf(),
-            name,
+            &path.to_path_buf(),
+            &name,
             parsed.as_fisa(),
         )?;
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -154,7 +154,7 @@ fn handle_module(
         context.func = func.clone();
         if flag_check_translation {
             context.verify(fisa).map_err(|err| {
-                pretty_verifier_error(&context.func, fisa.isa, err)
+                pretty_verifier_error(&context.func, fisa.isa, &err)
             })?;
         } else if let Some(isa) = fisa.isa {
             let compiled_size = context.compile(isa).map_err(|err| {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -68,8 +68,8 @@ fn handle_module(
     flag_check_translation: bool,
     flag_print: bool,
     flag_print_size: bool,
-    path: PathBuf,
-    name: String,
+    path: &PathBuf,
+    name: &str,
     fisa: FlagsOrIsa,
 ) -> Result<(), String> {
     let mut terminal = term::stdout().unwrap();
@@ -193,10 +193,7 @@ fn handle_module(
 
     if !flag_check_translation && flag_print_size {
         println!("Total module code size: {} bytes", total_module_code_size);
-        let total_bytecode_size = dummy_environ.func_bytecode_sizes.iter().fold(
-            0,
-            |sum, x| sum + x,
-        );
+        let total_bytecode_size: usize = dummy_environ.func_bytecode_sizes.iter().sum();
         println!("Total module bytecode size: {} bytes", total_bytecode_size);
     }
 

--- a/test-all.sh
+++ b/test-all.sh
@@ -55,4 +55,10 @@ cargo test --all --release
 banner "Rust documentation: $topdir/target/doc/cretonne/index.html"
 cargo doc
 
+# Run clippy if we have it.
+if $topdir/check-clippy.sh; then
+    banner "Rust linter"
+    $topdir/clippy-all.sh --write-mode=diff
+fi
+
 banner "OK"

--- a/test-all.sh
+++ b/test-all.sh
@@ -56,9 +56,11 @@ banner "Rust documentation: $topdir/target/doc/cretonne/index.html"
 cargo doc
 
 # Run clippy if we have it.
+banner "Rust linter"
 if $topdir/check-clippy.sh; then
-    banner "Rust linter"
     $topdir/clippy-all.sh --write-mode=diff
+else
+    echo "\`cargo +nightly install clippy\` for optional rust linting"
 fi
 
 banner "OK"

--- a/tests/filetests.rs
+++ b/tests/filetests.rs
@@ -3,5 +3,5 @@ extern crate cton_filetests;
 #[test]
 fn filetests() {
     // Run all the filetests in the following directories.
-    cton_filetests::run(false, vec!["filetests".into(), "docs".into()]).expect("test harness");
+    cton_filetests::run(false, &["filetests".into(), "docs".into()]).expect("test harness");
 }


### PR DESCRIPTION
This is a start at using clippy throughout Cretonne.

Current issues:
* Only `cargo +nightly clippy` works - stable cargo and clippy has a bug that seems to be related to the way arguments are passed when used in the root directory (works in all the other crates)
* Clippy and the old rustfmt we are using disagree about whether braces belong in some places - rustfmt insists on them, clippy flags them as a problem. (All of the problems clippy flags outside of cretonne were fixed until I ran rustfmt.)

Currently, there are a ton of lints turned off in the cretonne crate. A significant portion of them are fixable without much effort, but others would require doing work on the code generator.

Unfortunately, because generated code is made part of other source files via `include!()`, I wasn't put top level clippy pragmas in the generated sources only, because it wouldn't be at the top of the source file.

Fixes #264