### PR TITLE
[WIP] Initialize static-style heap bases in the entry block.

### DIFF
--- a/lib/cretonne/src/ir/function.rs
+++ b/lib/cretonne/src/ir/function.rs
@@ -11,6 +11,7 @@ use ir::{InstEncodings, ValueLocations, JumpTables, StackSlots, EbbOffsets, Sour
 use ir::{Ebb, JumpTableData, JumpTable, StackSlotData, StackSlot, SigRef, ExtFuncData, FuncRef,
          GlobalVarData, GlobalVar, HeapData, Heap};
 use isa::{TargetIsa, EncInfo};
+use packed_option::PackedOption;
 use std::fmt;
 use write::write_function;
 
@@ -43,6 +44,9 @@ pub struct Function {
 
     /// Layout of EBBs and instructions in the function body.
     pub layout: Layout,
+
+    /// Base addresses for static-style heaps.
+    pub static_heap_bases: EntityMap<Heap, PackedOption<ir::Value>>,
 
     /// Encoding recipe and bits for the legal instructions.
     /// Illegal instructions have the `Encoding::default()` value.
@@ -77,6 +81,7 @@ impl Function {
             jump_tables: PrimaryMap::new(),
             dfg: DataFlowGraph::new(),
             layout: Layout::new(),
+            static_heap_bases: EntityMap::new(),
             encodings: EntityMap::new(),
             locations: EntityMap::new(),
             offsets: EntityMap::new(),
@@ -93,6 +98,7 @@ impl Function {
         self.jump_tables.clear();
         self.dfg.clear();
         self.layout.clear();
+        self.static_heap_bases.clear();
         self.encodings.clear();
         self.locations.clear();
         self.offsets.clear();

--- a/lib/cretonne/src/legalizer/heap.rs
+++ b/lib/cretonne/src/legalizer/heap.rs
@@ -174,8 +174,13 @@ fn offset_addr(
     match pos.func.heaps[heap].base {
         ir::HeapBase::ReservedReg => unimplemented!(),
         ir::HeapBase::GlobalVar(base_gv) => {
-            let base_addr = pos.ins().global_addr(addr_ty, base_gv);
-            let base = pos.ins().load(addr_ty, MemFlags::new(), base_addr, 0);
+            let base = match pos.func.heaps[heap].style {
+                ir::HeapStyle::Static { .. } => pos.func.static_heap_bases[heap].unwrap(),
+                ir::HeapStyle::Dynamic { .. } => {
+                    let base_addr = pos.ins().global_addr(addr_ty, base_gv);
+                    pos.ins().load(addr_ty, MemFlags::new(), base_addr, 0)
+                }
+            };
             pos.func.dfg.replace(inst).iadd(base, offset);
         }
     }


### PR DESCRIPTION
Static-style heaps are allocated at a fixed address, so there's no need
to load their base address more than once per function. Instead of
load a base address before every heap access, load the bases of all
addresses once, in the function entry block.