### PR TITLE
Add a status summary to the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ ready for a production use case.
 
 Cretonne's APIs are not yet stable.
 
-Cretonne currently supports Rust 1.22.1 and later. We indent to always support
+Cretonne currently supports Rust 1.22.1 and later. We intend to always support
 the latest *stable* Rust. And, we currently support the version of Rust in the
 latest Ubuntu LTS, although whether we will always do so is not yet determined.
 Cretonne requires Python 2.7 or Python 3 to build.

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,6 @@ Cretonne is a low-level retargetable code generator. It translates a `target-ind
 intermediate representation <https://cretonne.readthedocs.io/en/latest/langref.html>`_ into executable
 machine code.
 
-*This is a work in progress that is not yet functional.*
-
 .. image:: https://readthedocs.org/projects/cretonne/badge/?version=latest
     :target: https://cretonne.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
@@ -22,6 +20,37 @@ machine code.
 
 For more information, see `the documentation
 <https://cretonne.readthedocs.io/en/latest/?badge=latest>`_.
+
+Status
+------
+
+Cretonne currently supports enough functionality to run a wide variety of
+programs, including all the functionality needed to execute WebAssembly MVP
+functions, although it needs to be used within an external WebAssembly
+embedding to be part of a complete WebAssembly implementation.
+
+The x86-64 backend is currently the most complete and stable; other
+architectures are in various stages of development. Cretonne currently supports
+the System V AMD64 ABI calling convention used on many platforms, but does not
+yet support the Windows x64 calling convention. The performance of code
+produced by Cretonne is not yet impressive, though we have plans to fix that.
+
+The core codegen creates have minimal dependencies, and do not require any host
+floating-point support. Support for `no_std` mode in the core codegen crates is
+[in development](https://github.com/Cretonne/cretonne/tree/no_std).
+
+Cretonne does not yet perform mitigations for Spectre or related security
+issues, though it may do so in the future. It does not currently make any
+security-relevant instruction timing guarantees. It has seen a fair amount
+of testing and fuzzing, although more work is needed before it would be
+ready for a production use case.
+
+Cretonne's APIs are not yet stable.
+
+Cretonne currently supports Rust 1.22.1 and later. We indent to always support
+the latest *stable* Rust. And, we currently support the version of Rust in the
+latest Ubuntu LTS, although whether we will always do so is not yet determined.
+Cretonne requires Python 2.7 or Python 3 to build.
 
 Planned uses
 ------------

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ produced by Cretonne is not yet impressive, though we have plans to fix that.
 
 The core codegen creates have minimal dependencies, and do not require any host
 floating-point support. Support for `no_std` mode in the core codegen crates is
-[in development](https://github.com/Cretonne/cretonne/tree/no_std).
+`in development <https://github.com/Cretonne/cretonne/tree/no_std>`_.
 
 Cretonne does not yet perform mitigations for Spectre or related security
 issues, though it may do so in the future. It does not currently make any

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ the System V AMD64 ABI calling convention used on many platforms, but does not
 yet support the Windows x64 calling convention. The performance of code
 produced by Cretonne is not yet impressive, though we have plans to fix that.
 
-The core codegen creates have minimal dependencies, and do not require any host
+The core codegen crates have minimal dependencies, and do not require any host
 floating-point support. Support for `no_std` mode in the core codegen crates is
 `in development <https://github.com/Cretonne/cretonne/tree/no_std>`_.
 


### PR DESCRIPTION
This adds a brief blurb about Cretonne's current status, so that people looking at Cretonne have an idea of what to expect.