### PR TITLE
Only save callee-saved registers that are used

### DIFF
--- a/filetests/isa/intel/prologue-epilogue.cton
+++ b/filetests/isa/intel/prologue-epilogue.cton
@@ -9,24 +9,14 @@ ebb0:
     return
 }
 
-; check: function %foo(i64 fp [%rbp], i64 csr [%rbx], i64 csr [%r12], i64 csr [%r13], i64 csr [%r14], i64 csr [%r15]) -> i64 fp [%rbp], i64 csr [%rbx], i64 csr [%r12], i64 csr [%r13], i64 csr [%r14], i64 csr [%r15] system_v {
-; nextln:     ss0 = explicit_slot 168, offset -224
-; nextln:     ss1 = incoming_arg 56, offset -56
-; check: ebb0(v0: i64 [%rbp], v1: i64 [%rbx], v2: i64 [%r12], v3: i64 [%r13], v4: i64 [%r14], v5: i64 [%r15]):
+; check: function %foo(i64 fp [%rbp]) -> i64 fp [%rbp] system_v {
+; nextln:     ss0 = explicit_slot 168, offset -184
+; nextln:     ss1 = incoming_arg 16, offset -16
+; check: ebb0(v0: i64 [%rbp]):
 ; nextln:     x86_push v0
 ; nextln:     copy_special %rsp -> %rbp
-; nextln:     x86_push v1
-; nextln:     x86_push v2
-; nextln:     x86_push v3
-; nextln:     x86_push v4
-; nextln:     x86_push v5
-; nextln:     adjust_sp_imm -168
-; nextln:     adjust_sp_imm 168
-; nextln:     v11 = x86_pop.i64
-; nextln:     v10 = x86_pop.i64
-; nextln:     v9 = x86_pop.i64
-; nextln:     v8 = x86_pop.i64
-; nextln:     v7 = x86_pop.i64
-; nextln:     v6 = x86_pop.i64
-; nextln:     return v6, v7, v8, v9, v10, v11
+; nextln:     adjust_sp_imm -176
+; nextln:     adjust_sp_imm 176
+; nextln:     v1 = x86_pop.i64
+; nextln:     return v1
 ; nextln: }

--- a/lib/cretonne/src/isa/arm32/abi.rs
+++ b/lib/cretonne/src/isa/arm32/abi.rs
@@ -3,7 +3,7 @@
 use super::registers::{D, GPR, Q, S};
 use ir;
 use isa::RegClass;
-use regalloc::AllocatableSet;
+use regalloc::RegisterSet;
 use settings as shared_settings;
 
 /// Legalize `sig`.
@@ -30,6 +30,6 @@ pub fn regclass_for_abi_type(ty: ir::Type) -> RegClass {
 }
 
 /// Get the set of allocatable registers for `func`.
-pub fn allocatable_registers(_func: &ir::Function) -> AllocatableSet {
+pub fn allocatable_registers(_func: &ir::Function) -> RegisterSet {
     unimplemented!()
 }

--- a/lib/cretonne/src/isa/arm32/mod.rs
+++ b/lib/cretonne/src/isa/arm32/mod.rs
@@ -92,7 +92,7 @@ impl TargetIsa for Isa {
         abi::regclass_for_abi_type(ty)
     }
 
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::AllocatableSet {
+    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet {
         abi::allocatable_registers(func)
     }
 

--- a/lib/cretonne/src/isa/arm64/abi.rs
+++ b/lib/cretonne/src/isa/arm64/abi.rs
@@ -3,7 +3,7 @@
 use super::registers::{FPR, GPR};
 use ir;
 use isa::RegClass;
-use regalloc::AllocatableSet;
+use regalloc::RegisterSet;
 use settings as shared_settings;
 
 /// Legalize `sig`.
@@ -21,6 +21,6 @@ pub fn regclass_for_abi_type(ty: ir::Type) -> RegClass {
 }
 
 /// Get the set of allocatable registers for `func`.
-pub fn allocatable_registers(_func: &ir::Function) -> AllocatableSet {
+pub fn allocatable_registers(_func: &ir::Function) -> RegisterSet {
     unimplemented!()
 }

--- a/lib/cretonne/src/isa/arm64/mod.rs
+++ b/lib/cretonne/src/isa/arm64/mod.rs
@@ -85,7 +85,7 @@ impl TargetIsa for Isa {
         abi::regclass_for_abi_type(ty)
     }
 
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::AllocatableSet {
+    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet {
         abi::allocatable_registers(func)
     }
 

--- a/lib/cretonne/src/isa/intel/abi.rs
+++ b/lib/cretonne/src/isa/intel/abi.rs
@@ -6,7 +6,8 @@ use cursor::{Cursor, CursorPosition, EncCursor};
 use ir;
 use ir::immediates::Imm64;
 use ir::stackslot::{StackOffset, StackSize};
-use ir::{AbiParam, ArgumentExtension, ArgumentLoc, ArgumentPurpose, CallConv, InstBuilder};
+use ir::{AbiParam, ArgumentExtension, ArgumentLoc, ArgumentPurpose, CallConv, InstBuilder,
+         ValueLoc};
 use isa::{RegClass, RegUnit, TargetIsa};
 use regalloc::AllocatableSet;
 use result;
@@ -168,6 +169,31 @@ pub fn callee_saved_registers(flags: &shared_settings::Flags) -> &'static [RU] {
     }
 }
 
+fn callee_saved_registers_used(
+    flags: &shared_settings::Flags,
+    func: &ir::Function,
+) -> AllocatableSet {
+    let mut all_callee_saved = AllocatableSet::empty();
+    for reg in callee_saved_registers(flags) {
+        all_callee_saved.free(GPR, *reg as RegUnit);
+    }
+
+    let mut used = AllocatableSet::empty();
+    for value_loc in func.locations.values() {
+        match value_loc {
+            &ValueLoc::Reg(ru) => {
+                if !used.is_avail(GPR, ru) {
+                    used.free(GPR, ru);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    used.intersect(&all_callee_saved);
+    return used;
+}
+
 pub fn prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::CtonResult {
     match func.signature.call_conv {
         ir::CallConv::SystemV => system_v_prologue_epilogue(func, isa),
@@ -203,7 +229,8 @@ pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> r
     } else {
         ir::types::I32
     };
-    let csrs = callee_saved_registers(isa.flags());
+
+    let csrs = callee_saved_registers_used(isa.flags(), func);
 
     // The reserved stack area is composed of:
     //   return address + frame pointer + all callee-saved registers
@@ -212,7 +239,7 @@ pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> r
     // instruction. Each of the others we will then push explicitly. Then we
     // will adjust the stack pointer to make room for the rest of the required
     // space for this frame.
-    let csr_stack_size = ((csrs.len() + 2) * word_size as usize) as i32;
+    let csr_stack_size = ((csrs.iter(GPR).len() + 2) * word_size as usize) as i32;
     func.create_stack_slot(ir::StackSlotData {
         kind: ir::StackSlotKind::IncomingArg,
         size: csr_stack_size as u32,
@@ -231,9 +258,8 @@ pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> r
     func.signature.params.push(fp_arg);
     func.signature.returns.push(fp_arg);
 
-    for csr in csrs.iter() {
-        let csr_arg =
-            ir::AbiParam::special_reg(csr_type, ir::ArgumentPurpose::CalleeSaved, *csr as RegUnit);
+    for csr in csrs.iter(GPR) {
+        let csr_arg = ir::AbiParam::special_reg(csr_type, ir::ArgumentPurpose::CalleeSaved, csr);
         func.signature.params.push(csr_arg);
         func.signature.returns.push(csr_arg);
     }
@@ -241,11 +267,11 @@ pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> r
     // Set up the cursor and insert the prologue
     let entry_ebb = func.layout.entry_block().expect("missing entry block");
     let mut pos = EncCursor::new(func, isa).at_first_insertion_point(entry_ebb);
-    insert_system_v_prologue(&mut pos, local_stack_size, csr_type, csrs);
+    insert_system_v_prologue(&mut pos, local_stack_size, csr_type, &csrs);
 
     // Reset the cursor and insert the epilogue
     let mut pos = pos.at_position(CursorPosition::Nowhere);
-    insert_system_v_epilogues(&mut pos, local_stack_size, csr_type, csrs);
+    insert_system_v_epilogues(&mut pos, local_stack_size, csr_type, &csrs);
 
     Ok(())
 }
@@ -255,7 +281,7 @@ fn insert_system_v_prologue(
     pos: &mut EncCursor,
     stack_size: i64,
     csr_type: ir::types::Type,
-    csrs: &'static [RU],
+    csrs: &AllocatableSet,
 ) {
     // Append param to entry EBB
     let ebb = pos.current_ebb().expect("missing ebb under cursor");
@@ -268,12 +294,12 @@ fn insert_system_v_prologue(
         RU::rbp as RegUnit,
     );
 
-    for reg in csrs.iter() {
+    for reg in csrs.iter(GPR) {
         // Append param to entry EBB
         let csr_arg = pos.func.dfg.append_ebb_param(ebb, csr_type);
 
         // Assign it a location
-        pos.func.locations[csr_arg] = ir::ValueLoc::Reg(*reg as RegUnit);
+        pos.func.locations[csr_arg] = ir::ValueLoc::Reg(reg);
 
         // Remember it so we can push it momentarily
         pos.ins().x86_push(csr_arg);
@@ -289,7 +315,7 @@ fn insert_system_v_epilogues(
     pos: &mut EncCursor,
     stack_size: i64,
     csr_type: ir::types::Type,
-    csrs: &'static [RU],
+    csrs: &AllocatableSet,
 ) {
     while let Some(ebb) = pos.next_ebb() {
         pos.goto_last_inst(ebb);
@@ -307,7 +333,7 @@ fn insert_system_v_epilogue(
     stack_size: i64,
     pos: &mut EncCursor,
     csr_type: ir::types::Type,
-    csrs: &'static [RU],
+    csrs: &AllocatableSet,
 ) {
     if stack_size > 0 {
         pos.ins().adjust_sp_imm(Imm64::new(stack_size));
@@ -321,11 +347,11 @@ fn insert_system_v_epilogue(
     pos.func.locations[fp_ret] = ir::ValueLoc::Reg(RU::rbp as RegUnit);
     pos.func.dfg.append_inst_arg(inst, fp_ret);
 
-    for reg in csrs.iter() {
+    for reg in csrs.iter(GPR) {
         let csr_ret = pos.ins().x86_pop(csr_type);
         pos.prev_inst();
 
-        pos.func.locations[csr_ret] = ir::ValueLoc::Reg(*reg as RegUnit);
+        pos.func.locations[csr_ret] = ir::ValueLoc::Reg(reg);
         pos.func.dfg.append_inst_arg(inst, csr_ret);
     }
 }

--- a/lib/cretonne/src/isa/intel/mod.rs
+++ b/lib/cretonne/src/isa/intel/mod.rs
@@ -98,7 +98,7 @@ impl TargetIsa for Isa {
         abi::regclass_for_abi_type(ty)
     }
 
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::AllocatableSet {
+    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet {
         abi::allocatable_registers(func, &self.shared_flags)
     }
 

--- a/lib/cretonne/src/isa/mod.rs
+++ b/lib/cretonne/src/isa/mod.rs
@@ -238,7 +238,7 @@ pub trait TargetIsa: fmt::Display {
     ///
     /// This set excludes reserved registers like the stack pointer and other special-purpose
     /// registers.
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::AllocatableSet;
+    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet;
 
     /// Compute the stack layout and insert prologue and epilogue code into `func`.
     ///

--- a/lib/cretonne/src/isa/riscv/abi.rs
+++ b/lib/cretonne/src/isa/riscv/abi.rs
@@ -10,7 +10,7 @@ use super::settings;
 use abi::{legalize_args, ArgAction, ArgAssigner, ValueConversion};
 use ir::{self, AbiParam, ArgumentExtension, ArgumentLoc, ArgumentPurpose, Type};
 use isa::RegClass;
-use regalloc::AllocatableSet;
+use regalloc::RegisterSet;
 use settings as shared_settings;
 use std::i32;
 
@@ -120,8 +120,8 @@ pub fn regclass_for_abi_type(ty: Type) -> RegClass {
     if ty.is_float() { FPR } else { GPR }
 }
 
-pub fn allocatable_registers(_func: &ir::Function, isa_flags: &settings::Flags) -> AllocatableSet {
-    let mut regs = AllocatableSet::new();
+pub fn allocatable_registers(_func: &ir::Function, isa_flags: &settings::Flags) -> RegisterSet {
+    let mut regs = RegisterSet::new();
     regs.take(GPR, GPR.unit(0)); // Hard-wired 0.
     // %x1 is the link register which is available for allocation.
     regs.take(GPR, GPR.unit(2)); // Stack pointer.

--- a/lib/cretonne/src/isa/riscv/mod.rs
+++ b/lib/cretonne/src/isa/riscv/mod.rs
@@ -92,7 +92,7 @@ impl TargetIsa for Isa {
         abi::regclass_for_abi_type(ty)
     }
 
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::AllocatableSet {
+    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet {
         abi::allocatable_registers(func, &self.isa_flags)
     }
 

--- a/lib/cretonne/src/regalloc/allocatable_set.rs
+++ b/lib/cretonne/src/regalloc/allocatable_set.rs
@@ -41,6 +41,10 @@ impl AllocatableSet {
         Self { avail: [!0; 3] }
     }
 
+    pub fn empty() -> Self {
+        Self { avail: [0; 3] }
+    }
+
     /// Returns `true` if the specified register is available.
     pub fn is_avail(&self, rc: RegClass, reg: RegUnit) -> bool {
         let (idx, bits) = bitmask(rc, reg);

--- a/lib/cretonne/src/regalloc/mod.rs
+++ b/lib/cretonne/src/regalloc/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains data structures and algorithms used for register allocation.
 
-pub mod allocatable_set;
+pub mod register_set;
 pub mod coloring;
 pub mod live_value_tracker;
 pub mod liveness;
@@ -18,7 +18,6 @@ mod reload;
 mod solver;
 mod spilling;
 
-pub use self::allocatable_set::AllocatableSet;
-pub use self::allocatable_set::RegSetIter;
+pub use self::register_set::RegisterSet;
 pub use self::context::Context;
 pub use self::diversion::RegDiversions;

--- a/lib/cretonne/src/regalloc/mod.rs
+++ b/lib/cretonne/src/regalloc/mod.rs
@@ -19,5 +19,6 @@ mod solver;
 mod spilling;
 
 pub use self::allocatable_set::AllocatableSet;
+pub use self::allocatable_set::RegSetIter;
 pub use self::context::Context;
 pub use self::diversion::RegDiversions;

--- a/lib/cretonne/src/regalloc/pressure.rs
+++ b/lib/cretonne/src/regalloc/pressure.rs
@@ -37,7 +37,7 @@
 #![allow(dead_code)]
 
 use isa::registers::{RegClass, RegClassMask, RegInfo, MAX_TRACKED_TOPRCS};
-use regalloc::AllocatableSet;
+use regalloc::RegisterSet;
 use std::cmp::min;
 use std::fmt;
 use std::iter::ExactSizeIterator;
@@ -81,7 +81,7 @@ pub struct Pressure {
 
 impl Pressure {
     /// Create a new register pressure tracker.
-    pub fn new(reginfo: &RegInfo, usable: &AllocatableSet) -> Pressure {
+    pub fn new(reginfo: &RegInfo, usable: &RegisterSet) -> Pressure {
         let mut p = Pressure {
             aliased: 0,
             toprc: Default::default(),
@@ -271,7 +271,7 @@ impl fmt::Display for Pressure {
 mod tests {
     use super::Pressure;
     use isa::{RegClass, TargetIsa};
-    use regalloc::AllocatableSet;
+    use regalloc::RegisterSet;
     use std::borrow::Borrow;
     use std::boxed::Box;
 
@@ -302,7 +302,7 @@ mod tests {
         let gpr = rc_by_name(isa, "GPR");
         let s = rc_by_name(isa, "S");
         let reginfo = isa.register_info();
-        let regs = AllocatableSet::new();
+        let regs = RegisterSet::new();
 
         let mut pressure = Pressure::new(&reginfo, &regs);
         let mut count = 0;
@@ -331,7 +331,7 @@ mod tests {
         let d = rc_by_name(isa, "D");
         let q = rc_by_name(isa, "Q");
         let reginfo = isa.register_info();
-        let regs = AllocatableSet::new();
+        let regs = RegisterSet::new();
 
         let mut pressure = Pressure::new(&reginfo, &regs);
         assert_eq!(pressure.check_avail(s), 0);

--- a/lib/cretonne/src/regalloc/register_set.rs
+++ b/lib/cretonne/src/regalloc/register_set.rs
@@ -41,6 +41,7 @@ impl RegisterSet {
         Self { avail: [!0; 3] }
     }
 
+    /// Create a new register set with no registers available.
     pub fn empty() -> Self {
         Self { avail: [0; 3] }
     }

--- a/lib/cretonne/src/regalloc/register_set.rs
+++ b/lib/cretonne/src/regalloc/register_set.rs
@@ -13,7 +13,7 @@ use std::mem::size_of_val;
 
 /// Set of registers available for allocation.
 #[derive(Clone)]
-pub struct AllocatableSet {
+pub struct RegisterSet {
     avail: RegUnitMask,
 }
 
@@ -32,7 +32,7 @@ fn bitmask(rc: RegClass, reg: RegUnit) -> (usize, u32) {
     (word_index, reg_bits)
 }
 
-impl AllocatableSet {
+impl RegisterSet {
     /// Create a new register set with all registers available.
     ///
     /// Note that this includes *all* registers. Query the `TargetIsa` object to get a set of
@@ -66,7 +66,7 @@ impl AllocatableSet {
         self.avail[idx] &= !bits;
     }
 
-    /// Make `reg` available for allocation again.
+    /// Return `reg` and all of its register units to the set of available registers.
     pub fn free(&mut self, rc: RegClass, reg: RegUnit) {
         let (idx, bits) = bitmask(rc, reg);
         debug_assert!(
@@ -102,15 +102,15 @@ impl AllocatableSet {
     /// of `other`.
     ///
     /// This assumes that unused bits are 1.
-    pub fn interferes_with(&self, other: &AllocatableSet) -> bool {
+    pub fn interferes_with(&self, other: &RegisterSet) -> bool {
         self.avail.iter().zip(&other.avail).any(
             |(&x, &y)| (x | y) != !0,
         )
     }
 
-    /// Intersect this set of allocatable registers with `other`. This has the effect of removing
-    /// any register units from this set that are not in `other`.
-    pub fn intersect(&mut self, other: &AllocatableSet) {
+    /// Intersect this set of registers with `other`. This has the effect of removing any register
+    /// units from this set that are not in `other`.
+    pub fn intersect(&mut self, other: &RegisterSet) {
         for (x, &y) in self.avail.iter_mut().zip(&other.avail) {
             *x &= y;
         }
@@ -118,8 +118,8 @@ impl AllocatableSet {
 
     /// Return an object that can display this register set, using the register info from the
     /// target ISA.
-    pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&self, regs: R) -> DisplayAllocatableSet<'a> {
-        DisplayAllocatableSet(self.clone(), regs.into())
+    pub fn display<'a, R: Into<Option<&'a RegInfo>>>(&self, regs: R) -> DisplayRegisterSet<'a> {
+        DisplayRegisterSet(self.clone(), regs.into())
     }
 }
 
@@ -161,10 +161,10 @@ impl Iterator for RegSetIter {
 
 impl ExactSizeIterator for RegSetIter {}
 
-/// Displaying an `AllocatableSet` correctly requires the associated `RegInfo` from the target ISA.
-pub struct DisplayAllocatableSet<'a>(AllocatableSet, Option<&'a RegInfo>);
+/// Displaying an `RegisterSet` correctly requires the associated `RegInfo` from the target ISA.
+pub struct DisplayRegisterSet<'a>(RegisterSet, Option<&'a RegInfo>);
 
-impl<'a> fmt::Display for DisplayAllocatableSet<'a> {
+impl<'a> fmt::Display for DisplayRegisterSet<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[")?;
         match self.1 {
@@ -215,7 +215,7 @@ impl<'a> fmt::Display for DisplayAllocatableSet<'a> {
     }
 }
 
-impl fmt::Display for AllocatableSet {
+impl fmt::Display for RegisterSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.display(None).fmt(f)
     }
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn put_and_take() {
-        let mut regs = AllocatableSet::new();
+        let mut regs = RegisterSet::new();
 
         // `GPR` has units 28-36.
         assert_eq!(regs.iter(GPR).len(), 8);
@@ -306,8 +306,8 @@ mod tests {
 
     #[test]
     fn interference() {
-        let mut regs1 = AllocatableSet::new();
-        let mut regs2 = AllocatableSet::new();
+        let mut regs1 = RegisterSet::new();
+        let mut regs2 = RegisterSet::new();
 
         assert!(!regs1.interferes_with(&regs2));
         regs1.take(&GPR, 32);


### PR DESCRIPTION
Currently we save all callee-saved registers in the prologue of every function, and restore them in the epilogue. With this PR, we now only save and restore those that are actually used in the function.

I'm not particularly happy with the code in this one. I feel like I'm abusing AllocatableSet. But it appears to work and can be refactored.

Test fixes/changes forthcoming.