### PR TITLE
Improvements to Modules API

### DIFF
--- a/lib/faerie/Cargo.toml
+++ b/lib/faerie/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 cretonne-codegen = { path = "../codegen", version = "0.6.0" }
 cretonne-module = { path = "../module", version = "0.6.0" }
-faerie = "0.2.0"
+faerie = "0.3.0"
 goblin = "0.0.14"
 failure = "0.1.1"
 

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -47,7 +47,11 @@ impl FaerieBuilder {
         format: container::Format,
         collect_traps: FaerieTrapCollection,
     ) -> Result<Self, ModuleError> {
-        debug_assert!(isa.flags().is_pic(), "faerie requires PIC");
+        if !isa.flags().is_pic() {
+            return Err(ModuleError::Backend(
+                "faerie requires TargetIsa be PIC".to_owned(),
+            ));
+        }
         let faerie_target = target::translate(&*isa)?;
         Ok(Self {
             isa,

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -28,5 +28,5 @@ mod backend;
 mod container;
 mod target;
 
-pub use backend::{FaerieBuilder, FaerieBackend};
+pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct};
 pub use container::Format;

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -29,5 +29,5 @@ mod container;
 mod target;
 pub mod traps;
 
-pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct};
+pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct, FaerieTrapCollection};
 pub use container::Format;

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -27,6 +27,7 @@ extern crate goblin;
 mod backend;
 mod container;
 mod target;
+pub mod traps;
 
 pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct};
 pub use container::Format;

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -21,7 +21,6 @@
 extern crate cretonne_codegen;
 extern crate cretonne_module;
 extern crate faerie;
-#[macro_use]
 extern crate failure;
 extern crate goblin;
 

--- a/lib/faerie/src/target.rs
+++ b/lib/faerie/src/target.rs
@@ -1,9 +1,9 @@
 use cretonne_codegen::isa;
+use cretonne_module::ModuleError;
 use faerie::Target;
-use failure::Error;
 
 /// Translate from a Cretonne `TargetIsa` to a Faerie `Target`.
-pub fn translate(isa: &isa::TargetIsa) -> Result<Target, Error> {
+pub fn translate(isa: &isa::TargetIsa) -> Result<Target, ModuleError> {
     let name = isa.name();
     match name {
         "x86" => Ok(if isa.flags().is_64bit() {
@@ -13,6 +13,8 @@ pub fn translate(isa: &isa::TargetIsa) -> Result<Target, Error> {
         }),
         "arm32" => Ok(Target::ARMv7),
         "arm64" => Ok(Target::ARM64),
-        _ => Err(format_err!("unsupported isa: {}", name)),
+        _ => Err(ModuleError::Backend(
+            format!("unsupported faerie isa: {}", name),
+        )),
     }
 }

--- a/lib/faerie/src/traps.rs
+++ b/lib/faerie/src/traps.rs
@@ -1,0 +1,64 @@
+//! Faerie trap manifests record every `TrapCode` that cretonne outputs during code generation,
+//! for every function in the module. This data may be useful at runtime.
+
+use cretonne_codegen::{ir, binemit};
+
+/// Record of the arguments cretonne passes to `TrapSink::trap`
+pub struct FaerieTrapSite {
+    /// Offset into function
+    pub offset: binemit::CodeOffset,
+    /// Source location given to cretonne
+    pub srcloc: ir::SourceLoc,
+    /// Trap code, as determined by cretonne
+    pub code: ir::TrapCode,
+}
+
+/// Record of the trap sites for a given function
+pub struct FaerieTrapSink {
+    /// Name of function
+    pub name: String,
+    /// Total code size of function
+    pub code_size: u32,
+    /// All trap sites collected in function
+    pub sites: Vec<FaerieTrapSite>,
+}
+
+
+impl FaerieTrapSink {
+    /// Create an empty `FaerieTrapSink`
+    pub fn new(name: &str, code_size: u32) -> Self {
+        Self {
+            sites: Vec::new(),
+            name: name.to_owned(),
+            code_size,
+        }
+    }
+}
+
+impl binemit::TrapSink for FaerieTrapSink {
+    fn trap(&mut self, offset: binemit::CodeOffset, srcloc: ir::SourceLoc, code: ir::TrapCode) {
+        self.sites.push(FaerieTrapSite {
+            offset,
+            srcloc,
+            code,
+        });
+    }
+}
+
+/// Collection of all `FaerieTrapSink`s for the module
+pub struct FaerieTrapManifest {
+    /// All `FaerieTrapSink` for the module
+    pub sinks: Vec<FaerieTrapSink>,
+}
+
+impl FaerieTrapManifest {
+    /// Create an empty `FaerieTrapManifest`
+    pub fn new() -> Self {
+        Self { sinks: Vec::new() }
+    }
+
+    /// Put a `FaerieTrapSink` into manifest
+    pub fn add_sink(&mut self, sink: FaerieTrapSink) {
+        self.sinks.push(sink);
+    }
+}

--- a/lib/module/Cargo.toml
+++ b/lib/module/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 cretonne-codegen = { path = "../codegen", version = "0.6.0", default-features = false }
 cretonne-entity = { path = "../entity", version = "0.6.0", default-features = false }
 hashmap_core = { version = "0.1.4", optional = true }
+failure = "0.1.1"
 
 [features]
 default = ["std"]

--- a/lib/module/src/backend.rs
+++ b/lib/module/src/backend.rs
@@ -3,9 +3,9 @@
 use DataContext;
 use Linkage;
 use ModuleNamespace;
+use ModuleError;
 use cretonne_codegen::Context;
 use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::result::CtonError;
 use cretonne_codegen::{binemit, ir};
 use std::marker;
 
@@ -57,19 +57,17 @@ where
         ctx: &Context,
         namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> Result<Self::CompiledFunction, CtonError>;
+    ) -> Result<Self::CompiledFunction, ModuleError>;
 
     /// Define a zero-initialized data object of the given size.
     ///
     /// Data objects must be declared before being defined.
-    ///
-    /// TODO: Is CtonError the right error code here?
     fn define_data(
         &mut self,
         name: &str,
         data_ctx: &DataContext,
         namespace: &ModuleNamespace<Self>,
-    ) -> Result<Self::CompiledData, CtonError>;
+    ) -> Result<Self::CompiledData, ModuleError>;
 
     /// Write the address of `what` into the data for `data` at `offset`. `data` must refer to a
     /// defined data object.

--- a/lib/module/src/data_context.rs
+++ b/lib/module/src/data_context.rs
@@ -94,7 +94,7 @@ impl DataContext {
         self.description.init = Init::Zeros { size };
     }
 
-    /// Define a zero-initialized object with the given size.
+    /// Define an object initialized with the given contents.
     ///
     /// TODO: Can we avoid a Box here?
     pub fn define(&mut self, contents: Box<[u8]>, writable: Writability) {

--- a/lib/module/src/lib.rs
+++ b/lib/module/src/lib.rs
@@ -16,9 +16,12 @@
                 use_self,
                 ))]
 
+#[macro_use]
 extern crate cretonne_codegen;
 #[macro_use]
 extern crate cretonne_entity;
+#[macro_use]
+extern crate failure;
 
 mod backend;
 mod data_context;
@@ -26,4 +29,4 @@ mod module;
 
 pub use backend::Backend;
 pub use data_context::{DataContext, Writability, DataDescription, Init};
-pub use module::{DataId, FuncId, Linkage, Module, ModuleNamespace};
+pub use module::{DataId, FuncId, FuncOrDataId, Linkage, Module, ModuleNamespace, ModuleError};

--- a/lib/module/src/module.rs
+++ b/lib/module/src/module.rs
@@ -215,7 +215,7 @@ where
             let func = FuncId::new(index as usize);
             &self.functions[func]
         } else {
-            panic!("unexpected ExternalName kind")
+            panic!("unexpected ExternalName kind {}", name)
         }
     }
 
@@ -226,7 +226,7 @@ where
             let data = DataId::new(index as usize);
             &self.data_objects[data]
         } else {
-            panic!("unexpected ExternalName kind")
+            panic!("unexpected ExternalName kind {}", name)
         }
     }
 }
@@ -285,7 +285,7 @@ where
         if let ir::ExternalName::User { namespace, .. } = *name {
             namespace == 0
         } else {
-            panic!("unexpected ExternalName kind")
+            panic!("unexpected ExternalName kind {}", name)
         }
     }
 }

--- a/lib/module/src/module.rs
+++ b/lib/module/src/module.rs
@@ -98,9 +98,9 @@ impl Linkage {
 /// A declared name may refer to either a function or data declaration
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub enum FuncOrDataId {
-    /// When its a FuncId
+    /// When it's a FuncId
     Func(FuncId),
-    /// When its a DataId
+    /// When it's a DataId
     Data(DataId),
 }
 
@@ -125,17 +125,17 @@ pub struct FunctionDeclaration {
 #[derive(Fail, Debug)]
 pub enum ModuleError {
     /// Indicates an identifier was used before it was declared
-    #[fail(display = "Undeclared identifier {}", _0)]
+    #[fail(display = "Undeclared identifier: {}", _0)]
     Undeclared(String),
     /// Indicates an identifier was used contrary to the way it was declared
-    #[fail(display = "Incompatible declaration of identifier {}", _0)]
+    #[fail(display = "Incompatible declaration of identifier: {}", _0)]
     IncompatibleDeclaration(String),
     /// Indicates an identifier was defined more than once
-    #[fail(display = "Duplicate definition of identifier {}", _0)]
+    #[fail(display = "Duplicate definition of identifier: {}", _0)]
     DuplicateDefinition(String),
     /// Indicates an identifier was defined, but was declared as an import
-    #[fail(display = "Invalid definition of identifier {}", _0)]
-    InvalidDefinition(String),
+    #[fail(display = "Invalid to define identifier declared as an import: {}", _0)]
+    InvalidImportDefinition(String),
     /// Wraps a `cretonne-codegen` error
     #[fail(display = "Compilation error: {}", _0)]
     Compilation(CtonError),
@@ -470,7 +470,7 @@ where
                 return Err(ModuleError::DuplicateDefinition(info.decl.name.clone()));
             }
             if !info.decl.linkage.is_definable() {
-                return Err(ModuleError::InvalidDefinition(info.decl.name.clone()));
+                return Err(ModuleError::InvalidImportDefinition(info.decl.name.clone()));
             }
             Some(self.backend.define_function(
                 &info.decl.name,
@@ -493,7 +493,7 @@ where
                 return Err(ModuleError::DuplicateDefinition(info.decl.name.clone()));
             }
             if !info.decl.linkage.is_definable() {
-                return Err(ModuleError::InvalidDefinition(info.decl.name.clone()));
+                return Err(ModuleError::InvalidImportDefinition(info.decl.name.clone()));
             }
             Some(self.backend.define_data(
                 &info.decl.name,

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -2,10 +2,9 @@
 
 use cretonne_codegen::binemit::{Addend, CodeOffset, Reloc, RelocSink, NullTrapSink};
 use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::result::CtonError;
 use cretonne_codegen::{self, ir, settings};
 use cretonne_module::{Backend, DataContext, Linkage, ModuleNamespace, Writability,
-                      DataDescription, Init};
+                      DataDescription, Init, ModuleError};
 use cretonne_native;
 use std::ffi::CString;
 use std::ptr;
@@ -116,7 +115,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         ctx: &cretonne_codegen::Context,
         _namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> Result<Self::CompiledFunction, CtonError> {
+    ) -> Result<Self::CompiledFunction, ModuleError> {
         let size = code_size as usize;
         let ptr = self.code_memory.allocate(size).expect(
             "TODO: handle OOM etc.",
@@ -139,7 +138,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         _name: &str,
         data: &DataContext,
         _namespace: &ModuleNamespace<Self>,
-    ) -> Result<Self::CompiledData, CtonError> {
+    ) -> Result<Self::CompiledData, ModuleError> {
         let &DataDescription {
             writable,
             ref init,

--- a/test-no_std.sh
+++ b/test-no_std.sh
@@ -21,10 +21,10 @@ do
     cd "lib/$LIB"
 
     # Test with just "core" enabled.
-    cargo test --no-default-features --features core
+    cargo +nightly test --no-default-features --features core
 
     # Test with "core" and "std" enabled at the same time.
-    cargo test --features core
+    cargo +nightly test --features core
 
     cd "$topdir"
 done


### PR DESCRIPTION
Defines an `enum ModuleError`, which derives `Fail`, to be used throughout `Module`. Implement `ModuleError` results at all the places that used to panic, or were otherwise unimplemented.

Exposes `Module::get_name(&self, &str) -> Option<FuncOrDataId>`, and the `FuncOrDataId` type. This is convenient for users so we don't have to do our own declaration bookkeeping.

This was spurred by a discussion about possibly adding string-name method variants (using declaration string names instead of FuncId or DataId). The `get_name` method allows the user to implement those themselves, if they are required.