### PR TITLE
Disassemble compiled binary for debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ serde = "1.0.8"
 serde_derive = "1.0.8"
 tempdir = "0.3.5"
 term = "0.5.1"
+capstone = "0.3.1"
 
 [workspace]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,8 +1,10 @@
 //! CLI tool to read Cretonne IR files and compile them into native code.
 
-use cretonne_codegen::Context;
+use capstone::prelude::*;
+use cretonne_codegen::isa::TargetIsa;
 use cretonne_codegen::print_errors::pretty_error;
 use cretonne_codegen::settings::FlagsOrIsa;
+use cretonne_codegen::Context;
 use cretonne_codegen::{binemit, ir};
 use cretonne_reader::parse_test;
 use std::path::Path;
@@ -78,9 +80,7 @@ fn handle_module(
     name: &str,
     fisa: FlagsOrIsa,
 ) -> Result<(), String> {
-    let buffer = read_to_string(&path).map_err(
-        |e| format!("{}: {}", name, e),
-    )?;
+    let buffer = read_to_string(&path).map_err(|e| format!("{}: {}", name, e))?;
     let test_file = parse_test(&buffer).map_err(|e| format!("{}: {}", name, e))?;
 
     // If we have an isa from the command-line, use that. Otherwise if the
@@ -121,8 +121,43 @@ fn handle_module(
                 print!("{}", byte);
             }
             println!();
+
+            let cs = get_disassembler(isa)?;
+
+            println!("\nDisassembly:");
+            let insns = cs.disasm_all(&mem, 0x0).unwrap();
+            for i in insns.iter() {
+                println!("{}", i);
+            }
         }
     }
 
     Ok(())
+}
+
+fn get_disassembler(isa: &TargetIsa) -> Result<Capstone, String> {
+    let cs = match isa.name() {
+        "riscv" => return Err(String::from("No disassembler for RiscV")),
+        "x86" => {
+            if isa.flags().is_64bit() {
+                Capstone::new()
+                    .x86()
+                    .mode(arch::x86::ArchMode::Mode64)
+                    .build()
+            } else {
+                Capstone::new()
+                    .x86()
+                    .mode(arch::x86::ArchMode::Mode32)
+                    .build()
+            }
+        }
+        "arm32" => Capstone::new().arm().mode(arch::arm::ArchMode::Arm).build(),
+        "arm64" => Capstone::new()
+            .arm64()
+            .mode(arch::arm64::ArchMode::Arm)
+            .build(),
+        _ => return Err(String::from("Unknown ISA")),
+    };
+
+    cs.map_err(|err| err.to_string())
 }

--- a/src/cton-util.rs
+++ b/src/cton-util.rs
@@ -20,6 +20,7 @@ extern crate filecheck;
 extern crate serde_derive;
 extern crate tempdir;
 extern crate term;
+extern crate capstone;
 
 use cretonne_codegen::{timing, VERSION};
 use docopt::Docopt;


### PR DESCRIPTION
Addresses https://github.com/cretonne/cretonne/issues/259. 

This adds Capstone as a dependency and uses it to disassemble and print the compiled machine code in cton-util. From the example in the above issue, it will now print...

```
.byte 64, 85, 72, 137, 229, 64, 93, 195

Disassembly:
0x0: push rbp
0x2: mov rbp, rsp
0x5: pop rbp
0x7: ret 
```