### PR TITLE
load_complex and store_complex instructions

### DIFF
--- a/docs/langref.rst
+++ b/docs/langref.rst
@@ -476,6 +476,11 @@ these instructions is undefined. If it is addressable but not
 There are also more restricted operations for accessing specific types of memory
 objects.
 
+Additionally, instructions are provided for handling multi-register addressing.
+
+.. autoinst:: load_complex
+.. autoinst:: store_complex
+
 Memory operation flags
 ----------------------
 

--- a/filetests/isa/x86/binary32-float.cton
+++ b/filetests/isa/x86/binary32-float.cton
@@ -227,6 +227,22 @@ ebb0:
     ; asm: ucomiss %xmm5, %xmm5
     [-,%rflags]         v312 = ffcmp v10, v10                   ; bin: 0f 2e ed
 
+    ; Load/Store Complex
+
+    [-,%rax]            v350 = iconst.i32 1
+    [-,%rbx]            v351 = iconst.i32 2
+
+    [-,%xmm5]           v352 = load_complex.f32 v350+v351               ; bin: heap_oob f3 0f 10 2c 18
+    [-,%xmm5]           v353 = load_complex.f32 v350+v351+50            ; bin: heap_oob f3 0f 10 6c 18 32
+    [-,%xmm5]           v354 = load_complex.f32 v350+v351-50            ; bin: heap_oob f3 0f 10 6c 18 ce
+    [-,%xmm5]           v355 = load_complex.f32 v350+v351+10000         ; bin: heap_oob f3 0f 10 ac 18 00002710
+    [-,%xmm5]           v356 = load_complex.f32 v350+v351-10000         ; bin: heap_oob f3 0f 10 ac 18 ffffd8f0
+    [-]                 store_complex.f32 v100, v350+v351               ; bin: heap_oob f3 0f 11 2c 18
+    [-]                 store_complex.f32 v100, v350+v351+50            ; bin: heap_oob f3 0f 11 6c 18 32
+    [-]                 store_complex.f32 v101, v350+v351-50            ; bin: heap_oob f3 0f 11 54 18 ce
+    [-]                 store_complex.f32 v100, v350+v351+10000         ; bin: heap_oob f3 0f 11 ac 18 00002710
+    [-]                 store_complex.f32 v101, v350+v351-10000         ; bin: heap_oob f3 0f 11 94 18 ffffd8f0
+
     return
 }
 

--- a/filetests/isa/x86/binary32.cton
+++ b/filetests/isa/x86/binary32.cton
@@ -432,6 +432,37 @@ ebb0:
     ; asm: shrl $8, %esi
     [-,%rsi]             v515 = ushr_imm v2, 8    ; bin: c1 ee 08
 
+    ; Load Complex
+    [-,%rax]            v521 = iconst.i32 1
+    [-,%rbx]            v522 = iconst.i32 1
+    ; asm: movl (%eax,%ebx,1), %ecx
+    [-,%rcx]            v526 = load_complex.i32 v521+v522         ; bin: heap_oob 8b 0c 18
+    ; asm: movl 1(%eax,%ebx,1), %ecx
+    [-,%rcx]            v528 = load_complex.i32 v521+v522+1       ; bin: heap_oob 8b 4c 18 01
+    ; asm: mov    0x100000(%eax,%ebx,1),%ecx
+    [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
+    ; asm: movzbl (%eax,%ebx,1),%ecx
+    [-,%rcx]            v532 = uload8_complex.i32 v521+v522         ; bin: heap_oob 0f b6 0c 18
+    ; asm: movsbl (%eax,%ebx,1),%ecx
+    [-,%rcx]            v534 = sload8_complex.i32 v521+v522         ; bin: heap_oob 0f be 0c 18
+    ; asm: movzwl (%eax,%ebx,1),%ecx
+    [-,%rcx]            v536 = uload16_complex.i32 v521+v522         ; bin: heap_oob 0f b7 0c 18
+    ; asm: movswl (%eax,%ebx,1),%ecx
+    [-,%rcx]            v538 = sload16_complex.i32 v521+v522         ; bin: heap_oob 0f bf 0c 18
+
+    ; Store Complex
+    [-,%rcx]            v601 = iconst.i32 1
+    ; asm: mov    %ecx,(%eax,%ebx,1)
+    store_complex v601, v521+v522        ; bin: heap_oob 89 0c 18
+    ; asm: mov    %ecx,0x1(%eax,%ebx,1)
+    store_complex v601, v521+v522+1      ; bin: heap_oob 89 4c 18 01
+    ; asm: mov    %ecx,0x100000(%eax,%ebx,1)
+    store_complex v601, v521+v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
+    ; asm: mov    %cx,(%eax,%ebx,1)
+    istore16_complex v601, v521+v522     ; bin: heap_oob 66 89 0c 18
+    ; asm: mov    %cl,(%eax,%ebx,1)
+    istore8_complex v601, v521+v522      ; bin: heap_oob 88 0c 18
+
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 85 c9 74 0e

--- a/filetests/isa/x86/binary64-float.cton
+++ b/filetests/isa/x86/binary64-float.cton
@@ -241,6 +241,30 @@ ebb0:
     ; asm: ucomiss %xmm5, %xmm5
     [-,%rflags]         v312 = ffcmp v10, v10                   ; bin: 0f 2e ed
 
+
+    ; Load/Store Complex
+
+    [-,%rax]            v350 = iconst.i64 1
+    [-,%rbx]            v351 = iconst.i64 2
+
+    ; asm: movsd (%r14), %xmm5
+    [-,%xmm5]           v352 = load_complex.f32 v350+v351               ; bin: heap_oob f3 0f 10 2c 18
+    [-,%xmm5]           v353 = load_complex.f32 v350+v351+50            ; bin: heap_oob f3 0f 10 6c 18 32
+    [-,%xmm10]          v354 = load_complex.f32 v350+v351-50            ; bin: heap_oob f3 44 0f 10 54 18 ce
+    [-,%xmm5]           v355 = load_complex.f32 v350+v351+10000         ; bin: heap_oob f3 0f 10 ac 18 00002710
+    [-,%xmm10]          v356 = load_complex.f32 v350+v351-10000         ; bin: heap_oob f3 44 0f 10 94 18 ffffd8f0
+
+    ; asm: movsd %xmm5, (%rax,%rbx,1)
+    [-]                 store_complex.f32 v100, v350+v351               ; bin: heap_oob f3 0f 11 2c 18
+    ; asm: movsd %xmm5, 50(%rax,%rbx,1)
+    [-]                 store_complex.f32 v100, v350+v351+50            ; bin: heap_oob f3 0f 11 6c 18 32
+    ; asm: movsd %xmm10, -50(%rax,%rbx,1)
+    [-]                 store_complex.f32 v101, v350+v351-50            ; bin: heap_oob f3 44 0f 11 54 18 ce
+    ; asm: movsd %xmm5, 10000(%rax,%rbx,1)
+    [-]                 store_complex.f32 v100, v350+v351+10000         ; bin: heap_oob f3 0f 11 ac 18 00002710
+    ; asm: movsd %xmm10, -10000(%rax,%rbx,1)
+    [-]                 store_complex.f32 v101, v350+v351-10000         ; bin: heap_oob f3 44 0f 11 94 18 ffffd8f0
+
     return
 }
 
@@ -475,6 +499,29 @@ ebb0:
     [-,%rflags]         v311 = ffcmp v11, v10                   ; bin: 66 44 0f 2e d5
     ; asm: ucomisd %xmm5, %xmm5
     [-,%rflags]         v312 = ffcmp v10, v10                   ; bin: 66 0f 2e ed
+
+    ; Load/Store Complex
+
+    [-,%rax]            v350 = iconst.i64 1
+    [-,%rbx]            v351 = iconst.i64 2
+
+    ; asm: movsd (%r14), %xmm5
+    [-,%xmm5]           v352 = load_complex.f64 v350+v351               ; bin: heap_oob f2 0f 10 2c 18
+    [-,%xmm5]           v353 = load_complex.f64 v350+v351+50            ; bin: heap_oob f2 0f 10 6c 18 32
+    [-,%xmm10]          v354 = load_complex.f64 v350+v351-50            ; bin: heap_oob f2 44 0f 10 54 18 ce
+    [-,%xmm5]           v355 = load_complex.f64 v350+v351+10000         ; bin: heap_oob f2 0f 10 ac 18 00002710
+    [-,%xmm10]          v356 = load_complex.f64 v350+v351-10000         ; bin: heap_oob f2 44 0f 10 94 18 ffffd8f0
+
+    ; asm: movsd %xmm5, (%rax,%rbx,1)
+    [-]                 store_complex.f64 v100, v350+v351               ; bin: heap_oob f2 0f 11 2c 18
+    ; asm: movsd %xmm5, 50(%rax,%rbx,1)
+    [-]                 store_complex.f64 v100, v350+v351+50            ; bin: heap_oob f2 0f 11 6c 18 32
+    ; asm: movsd %xmm10, -50(%rax,%rbx,1)
+    [-]                 store_complex.f64 v101, v350+v351-50            ; bin: heap_oob f2 44 0f 11 54 18 ce
+    ; asm: movsd %xmm5, 10000(%rax,%rbx,1)
+    [-]                 store_complex.f64 v100, v350+v351+10000         ; bin: heap_oob f2 0f 11 ac 18 00002710
+    ; asm: movsd %xmm10, -10000(%rax,%rbx,1)
+    [-]                 store_complex.f64 v101, v350+v351-10000         ; bin: heap_oob f2 44 0f 11 94 18 ffffd8f0
 
     return
 }

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -607,32 +607,56 @@ ebb0:
     [-,%rcx]            v527 = load_complex.i64 v521+v522+1       ; bin: heap_oob 48 8b 4c 18 01
     ; asm: movl 1(%rax,%rbx,1), %ecx
     [-,%rcx]            v528 = load_complex.i32 v521+v522+1       ; bin: heap_oob 8b 4c 18 01
+
+    ; asm: mov    0x100000(%rax,%rbx,1),%rcx
     [-,%rcx]            v529 = load_complex.i64 v521+v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
+    ; asm: mov    0x100000(%rax,%rbx,1),%ecx
     [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
+    ; asm: movzbq (%rax,%rbx,1),%rcx
     [-,%rcx]            v531 = uload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f b6 0c 18
+    ; asm: movzbl (%rax,%rbx,1),%ecx
     [-,%rcx]            v532 = uload8_complex.i32 v521+v522         ; bin: heap_oob 0f b6 0c 18
+    ; asm: movsbq (%rax,%rbx,1),%rcx
     [-,%rcx]            v533 = sload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f be 0c 18
+    ; asm: movsbl (%rax,%rbx,1),%ecx
     [-,%rcx]            v534 = sload8_complex.i32 v521+v522         ; bin: heap_oob 0f be 0c 18
+    ; asm: movzwq (%rax,%rbx,1),%rcx
     [-,%rcx]            v535 = uload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f b7 0c 18
+    ; asm: movzwl (%rax,%rbx,1),%ecx
     [-,%rcx]            v536 = uload16_complex.i32 v521+v522         ; bin: heap_oob 0f b7 0c 18
+    ; asm: movswq (%rax,%rbx,1),%rcx
     [-,%rcx]            v537 = sload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f bf 0c 18
+    ; asm: movswl (%rax,%rbx,1),%ecx
     [-,%rcx]            v538 = sload16_complex.i32 v521+v522         ; bin: heap_oob 0f bf 0c 18
+    ; asm: mov    (%rax,%rbx,1),%ecx
     [-,%rcx]            v539 = uload32_complex v521+v522             ; bin: heap_oob 8b 0c 18
+    ; asm: movslq (%rax,%rbx,1),%rcx
     [-,%rcx]            v540 = sload32_complex v521+v522             ; bin: heap_oob 48 63 0c 18
 
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
     [-,%rcx]            v601 = iconst.i32 1
+    ; asm: mov    %rcx,(%rax,%rbx,1)
     store_complex v600, v521+v522        ; bin: heap_oob 48 89 0c 18
+    ; asm: mov    %rcx,0x1(%rax,%rbx,1)
     store_complex v600, v521+v522+1      ; bin: heap_oob 48 89 4c 18 01
+    ; asm: mov    %rcx,0x100000(%rax,%rbx,1)
     store_complex v600, v521+v522+0x1000 ; bin: heap_oob 48 89 8c 18 00001000
+    ; asm: mov    %ecx,(%rax,%rbx,1)
     store_complex v601, v521+v522        ; bin: heap_oob 89 0c 18
+    ; asm: mov    %ecx,0x1(%rax,%rbx,1)
     store_complex v601, v521+v522+1      ; bin: heap_oob 89 4c 18 01
+    ; asm: mov    %ecx,0x100000(%rax,%rbx,1)
     store_complex v601, v521+v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
+    ; asm: mov    %ecx,(%rax,%rbx,1)
     istore32_complex v600, v521+v522     ; bin: heap_oob 89 0c 18
+    ; asm: data16 mov %rcx,(%rax,%rbx,1)
     istore16_complex v600, v521+v522     ; bin: heap_oob 66 48 89 0c 18
+    ; asm: mov    %cx,(%rax,%rbx,1)
     istore16_complex v601, v521+v522     ; bin: heap_oob 66 89 0c 18
+    ; asm: mov    %cl,(%rax,%rbx,1)
     istore8_complex v600, v521+v522      ; bin: heap_oob 88 0c 18
+    ; asm: mov    %cl,(%rax,%rbx,1)
     istore8_complex v601, v521+v522      ; bin: heap_oob 88 0c 18
 
     ; asm: testq %rcx, %rcx

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -639,6 +639,8 @@ ebb0:
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
     [-,%rcx]            v601 = iconst.i32 1
+    [-,%r10]            v602 = iconst.i64 1
+    [-,%r11]            v603 = iconst.i32 1
     ; asm: mov    %rcx,(%rax,%rbx,1)
     store_complex v600, v521+v522               ; bin: heap_oob 48 89 0c 18
     ; asm: mov    %rcx,0x1(%rax,%rbx,1)
@@ -653,10 +655,14 @@ ebb0:
     store_complex v601, v521+v522+0x1000        ; bin: heap_oob 89 8c 18 00001000
     ; asm: mov    %ecx,(%rax,%rbx,1)
     istore32_complex v600, v521+v522            ; bin: heap_oob 89 0c 18
-    ; asm: data16 mov %rcx,(%rax,%rbx,1)
-    istore16_complex v600, v521+v522            ; bin: heap_oob 66 48 89 0c 18
+    ; asm: mov    %cx,(%rax,%rbx,1)
+    istore16_complex v600, v521+v522            ; bin: heap_oob 66 89 0c 18
     ; asm: mov    %cx,(%rax,%rbx,1)
     istore16_complex v601, v521+v522            ; bin: heap_oob 66 89 0c 18
+    ; asm: mov    %r10w,(%rax,%rbx,1)
+    istore16_complex v602, v521+v522            ; bin: heap_oob 66 44 89 14 18
+    ; asm: mov    %r11w,(%rax,%rbx,1)
+    istore16_complex v603, v521+v522            ; bin: heap_oob 66 44 89 1c 18
     ; asm: mov    %cl,(%rax,%rbx,1)
     istore8_complex v600, v521+v522             ; bin: heap_oob 88 0c 18
     ; asm: mov    %cl,(%rax,%rbx,1)

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -600,69 +600,67 @@ ebb0:
     [-,%rdi]            v523 = iconst.i32 1
     [-,%rsi]            v524 = iconst.i32 1
     ; asm: movq (%rax,%rbx,1), %rcx
-    [-,%rcx]            v525 = load_complex.i64 v521+v522         ; bin: heap_oob 48 8b 0c 18
+    [-,%rcx]            v525 = load_complex.i64 v521+v522               ; bin: heap_oob 48 8b 0c 18
     ; asm: movl (%rax,%rbx,1), %ecx
-    [-,%rcx]            v526 = load_complex.i32 v521+v522         ; bin: heap_oob 8b 0c 18
+    [-,%rcx]            v526 = load_complex.i32 v521+v522               ; bin: heap_oob 8b 0c 18
     ; asm: movq 1(%rax,%rbx,1), %rcx
-    [-,%rcx]            v527 = load_complex.i64 v521+v522+1       ; bin: heap_oob 48 8b 4c 18 01
+    [-,%rcx]            v527 = load_complex.i64 v521+v522+1             ; bin: heap_oob 48 8b 4c 18 01
     ; asm: movl 1(%rax,%rbx,1), %ecx
-    [-,%rcx]            v528 = load_complex.i32 v521+v522+1       ; bin: heap_oob 8b 4c 18 01
-
+    [-,%rcx]            v528 = load_complex.i32 v521+v522+1             ; bin: heap_oob 8b 4c 18 01
     ; asm: mov    0x100000(%rax,%rbx,1),%rcx
-    [-,%rcx]            v529 = load_complex.i64 v521+v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
+    [-,%rcx]            v529 = load_complex.i64 v521+v522+0x1000        ; bin: heap_oob 48 8b 8c 18 00001000
     ; asm: mov    0x100000(%rax,%rbx,1),%ecx
-    [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
+    [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000        ; bin: heap_oob 8b 8c 18 00001000
     ; asm: movzbq (%rax,%rbx,1),%rcx
-    [-,%rcx]            v531 = uload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f b6 0c 18
+    [-,%rcx]            v531 = uload8_complex.i64 v521+v522             ; bin: heap_oob 48 0f b6 0c 18
     ; asm: movzbl (%rax,%rbx,1),%ecx
-    [-,%rcx]            v532 = uload8_complex.i32 v521+v522         ; bin: heap_oob 0f b6 0c 18
+    [-,%rcx]            v532 = uload8_complex.i32 v521+v522             ; bin: heap_oob 0f b6 0c 18
     ; asm: movsbq (%rax,%rbx,1),%rcx
-    [-,%rcx]            v533 = sload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f be 0c 18
+    [-,%rcx]            v533 = sload8_complex.i64 v521+v522             ; bin: heap_oob 48 0f be 0c 18
     ; asm: movsbl (%rax,%rbx,1),%ecx
-    [-,%rcx]            v534 = sload8_complex.i32 v521+v522         ; bin: heap_oob 0f be 0c 18
+    [-,%rcx]            v534 = sload8_complex.i32 v521+v522             ; bin: heap_oob 0f be 0c 18
     ; asm: movzwq (%rax,%rbx,1),%rcx
-    [-,%rcx]            v535 = uload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f b7 0c 18
+    [-,%rcx]            v535 = uload16_complex.i64 v521+v522            ; bin: heap_oob 48 0f b7 0c 18
     ; asm: movzwl (%rax,%rbx,1),%ecx
-    [-,%rcx]            v536 = uload16_complex.i32 v521+v522         ; bin: heap_oob 0f b7 0c 18
+    [-,%rcx]            v536 = uload16_complex.i32 v521+v522            ; bin: heap_oob 0f b7 0c 18
     ; asm: movswq (%rax,%rbx,1),%rcx
-    [-,%rcx]            v537 = sload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f bf 0c 18
+    [-,%rcx]            v537 = sload16_complex.i64 v521+v522            ; bin: heap_oob 48 0f bf 0c 18
     ; asm: movswl (%rax,%rbx,1),%ecx
-    [-,%rcx]            v538 = sload16_complex.i32 v521+v522         ; bin: heap_oob 0f bf 0c 18
+    [-,%rcx]            v538 = sload16_complex.i32 v521+v522            ; bin: heap_oob 0f bf 0c 18
     ; asm: mov    (%rax,%rbx,1),%ecx
-    [-,%rcx]            v539 = uload32_complex v521+v522             ; bin: heap_oob 8b 0c 18
+    [-,%rcx]            v539 = uload32_complex v521+v522                ; bin: heap_oob 8b 0c 18
     ; asm: movslq (%rax,%rbx,1),%rcx
-    [-,%rcx]            v540 = sload32_complex v521+v522             ; bin: heap_oob 48 63 0c 18
-
+    [-,%rcx]            v540 = sload32_complex v521+v522                ; bin: heap_oob 48 63 0c 18
     [-,%r13]            v550 = iconst.i64 1
     [-,%r14]            v551 = iconst.i64 1
     ; asm: mov 0x0(%r13,%r14,1),%r12d
-    [-,%r12]            v552 = load_complex.i32 v550+v551            ; bin: heap_oob 47 8b 64 35 00
+    [-,%r12]            v552 = load_complex.i32 v550+v551               ; bin: heap_oob 47 8b 64 35 00
 
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
     [-,%rcx]            v601 = iconst.i32 1
     ; asm: mov    %rcx,(%rax,%rbx,1)
-    store_complex v600, v521+v522        ; bin: heap_oob 48 89 0c 18
+    store_complex v600, v521+v522               ; bin: heap_oob 48 89 0c 18
     ; asm: mov    %rcx,0x1(%rax,%rbx,1)
-    store_complex v600, v521+v522+1      ; bin: heap_oob 48 89 4c 18 01
+    store_complex v600, v521+v522+1             ; bin: heap_oob 48 89 4c 18 01
     ; asm: mov    %rcx,0x100000(%rax,%rbx,1)
-    store_complex v600, v521+v522+0x1000 ; bin: heap_oob 48 89 8c 18 00001000
+    store_complex v600, v521+v522+0x1000        ; bin: heap_oob 48 89 8c 18 00001000
     ; asm: mov    %ecx,(%rax,%rbx,1)
-    store_complex v601, v521+v522        ; bin: heap_oob 89 0c 18
+    store_complex v601, v521+v522               ; bin: heap_oob 89 0c 18
     ; asm: mov    %ecx,0x1(%rax,%rbx,1)
-    store_complex v601, v521+v522+1      ; bin: heap_oob 89 4c 18 01
+    store_complex v601, v521+v522+1             ; bin: heap_oob 89 4c 18 01
     ; asm: mov    %ecx,0x100000(%rax,%rbx,1)
-    store_complex v601, v521+v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
+    store_complex v601, v521+v522+0x1000        ; bin: heap_oob 89 8c 18 00001000
     ; asm: mov    %ecx,(%rax,%rbx,1)
-    istore32_complex v600, v521+v522     ; bin: heap_oob 89 0c 18
+    istore32_complex v600, v521+v522            ; bin: heap_oob 89 0c 18
     ; asm: data16 mov %rcx,(%rax,%rbx,1)
-    istore16_complex v600, v521+v522     ; bin: heap_oob 66 48 89 0c 18
+    istore16_complex v600, v521+v522            ; bin: heap_oob 66 48 89 0c 18
     ; asm: mov    %cx,(%rax,%rbx,1)
-    istore16_complex v601, v521+v522     ; bin: heap_oob 66 89 0c 18
+    istore16_complex v601, v521+v522            ; bin: heap_oob 66 89 0c 18
     ; asm: mov    %cl,(%rax,%rbx,1)
-    istore8_complex v600, v521+v522      ; bin: heap_oob 88 0c 18
+    istore8_complex v600, v521+v522             ; bin: heap_oob 88 0c 18
     ; asm: mov    %cl,(%rax,%rbx,1)
-    istore8_complex v601, v521+v522      ; bin: heap_oob 88 0c 18
+    istore8_complex v601, v521+v522             ; bin: heap_oob 88 0c 18
 
     ; asm: testq %rcx, %rcx
     ; asm: je ebb1

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -600,26 +600,26 @@ ebb0:
     [-,%rdi]            v523 = iconst.i32 1
     [-,%rsi]            v524 = iconst.i32 1
     ; asm: movq (%rax,%rbx,1), %rcx
-    [-,%rcx]            v525 = load_complex.i64 v521,v522         ; bin: heap_oob 48 8b 0c 18
+    [-,%rcx]            v525 = load_complex.i64 v521+v522         ; bin: heap_oob 48 8b 0c 18
     ; asm: movl (%rax,%rbx,1), %ecx
-    [-,%rcx]            v526 = load_complex.i32 v521,v522         ; bin: heap_oob 8b 0c 18
+    [-,%rcx]            v526 = load_complex.i32 v521+v522         ; bin: heap_oob 8b 0c 18
     ; asm: movq 1(%rax,%rbx,1), %rcx
-    [-,%rcx]            v527 = load_complex.i64 v521,v522+1       ; bin: heap_oob 48 8b 4c 18 01
+    [-,%rcx]            v527 = load_complex.i64 v521+v522+1       ; bin: heap_oob 48 8b 4c 18 01
     ; asm: movl 1(%rax,%rbx,1), %ecx
-    [-,%rcx]            v528 = load_complex.i32 v521,v522+1       ; bin: heap_oob 8b 4c 18 01
+    [-,%rcx]            v528 = load_complex.i32 v521+v522+1       ; bin: heap_oob 8b 4c 18 01
 
-    [-,%rcx]            v529 = load_complex.i64 v521,v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
-    [-,%rcx]            v530 = load_complex.i32 v521,v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
+    [-,%rcx]            v529 = load_complex.i64 v521+v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
+    [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
 
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
-    store_complex v600, v521,v522        ; bin: heap_oob 48 89 0c 18
-    store_complex v600, v521,v522+1      ; bin: heap_oob 48 89 4c 18 01
-    store_complex v600, v521,v522+0x1000 ; bin: heap_oob 48 89 8c 18 00001000
+    store_complex v600, v521+v522        ; bin: heap_oob 48 89 0c 18
+    store_complex v600, v521+v522+1      ; bin: heap_oob 48 89 4c 18 01
+    store_complex v600, v521+v522+0x1000 ; bin: heap_oob 48 89 8c 18 00001000
     [-,%rcx]            v601 = iconst.i32 1
-    store_complex v601, v521,v522        ; bin: heap_oob 89 0c 18
-    store_complex v601, v521,v522+1      ; bin: heap_oob 89 4c 18 01
-    store_complex v601, v521,v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
+    store_complex v601, v521+v522        ; bin: heap_oob 89 0c 18
+    store_complex v601, v521+v522+1      ; bin: heap_oob 89 4c 18 01
+    store_complex v601, v521+v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
 
 
     ; asm: testq %rcx, %rcx

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -594,7 +594,7 @@ ebb0:
     [-,%r8]              v520 = ushr_imm v4, 63   ; bin: 49 c1 e8 3f
 
 
-    ; Load/Store Complex
+    ; Load Complex
     [-,%rax]            v521 = iconst.i64 1
     [-,%rbx]            v522 = iconst.i64 1
     [-,%rdi]            v523 = iconst.i32 1
@@ -607,10 +607,19 @@ ebb0:
     [-,%rcx]            v527 = load_complex.i64 v521,v522+1       ; bin: heap_oob 48 8b 4c 18 01
     ; asm: movl 1(%rax,%rbx,1), %ecx
     [-,%rcx]            v528 = load_complex.i32 v521,v522+1       ; bin: heap_oob 8b 4c 18 01
-    
+
     [-,%rcx]            v529 = load_complex.i64 v521,v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
-    ; asm: movl 1(%rax,%rbx,1), %ecx
     [-,%rcx]            v530 = load_complex.i32 v521,v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
+
+    ; Store Complex
+    [-,%rcx]            v600 = iconst.i64 1
+    store_complex v600, v521,v522        ; bin: heap_oob 48 89 0c 18
+    store_complex v600, v521,v522+1      ; bin: heap_oob 48 89 4c 18 01
+    store_complex v600, v521,v522+0x1000 ; bin: heap_oob 48 89 8c 18 00001000
+    [-,%rcx]            v601 = iconst.i32 1
+    store_complex v601, v521,v522        ; bin: heap_oob 89 0c 18
+    store_complex v601, v521,v522+1      ; bin: heap_oob 89 4c 18 01
+    store_complex v601, v521,v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
 
 
     ; asm: testq %rcx, %rcx

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -597,12 +597,20 @@ ebb0:
     ; Load/Store Complex
     [-,%rax]            v521 = iconst.i64 1
     [-,%rbx]            v522 = iconst.i64 1
+    [-,%rdi]            v523 = iconst.i32 1
+    [-,%rsi]            v524 = iconst.i32 1
     ; asm: movq (%rax,%rbx,1), %rcx
-    [-,%rcx]            v523 = load_complex.i64 v521,v522      ; bin: heap_oob 48 8b 0c 18
-    [-,%rcx]            v524 = load_complex.i32 v521,v522      ; bin: heap_oob 8b 0c 18
-    [-,%rcx]            v525 = load_complex.i64 v521,v522+1    ; bin: heap_oob 48 8b 4c 18 01
-    [-,%rcx]            v526 = load_complex.i32 v521,v522+1    ; bin: heap_oob 8b 4c 18 01
-
+    [-,%rcx]            v525 = load_complex.i64 v521,v522         ; bin: heap_oob 48 8b 0c 18
+    ; asm: movl (%rax,%rbx,1), %ecx
+    [-,%rcx]            v526 = load_complex.i32 v521,v522         ; bin: heap_oob 8b 0c 18
+    ; asm: movq 1(%rax,%rbx,1), %rcx
+    [-,%rcx]            v527 = load_complex.i64 v521,v522+1       ; bin: heap_oob 48 8b 4c 18 01
+    ; asm: movl 1(%rax,%rbx,1), %ecx
+    [-,%rcx]            v528 = load_complex.i32 v521,v522+1       ; bin: heap_oob 8b 4c 18 01
+    
+    [-,%rcx]            v529 = load_complex.i64 v521,v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
+    ; asm: movl 1(%rax,%rbx,1), %ecx
+    [-,%rcx]            v530 = load_complex.i32 v521,v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
 
 
     ; asm: testq %rcx, %rcx

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -607,35 +607,33 @@ ebb0:
     [-,%rcx]            v527 = load_complex.i64 v521+v522+1       ; bin: heap_oob 48 8b 4c 18 01
     ; asm: movl 1(%rax,%rbx,1), %ecx
     [-,%rcx]            v528 = load_complex.i32 v521+v522+1       ; bin: heap_oob 8b 4c 18 01
-
     [-,%rcx]            v529 = load_complex.i64 v521+v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
     [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
-
     [-,%rcx]            v531 = uload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f b6 0c 18
     [-,%rcx]            v532 = uload8_complex.i32 v521+v522         ; bin: heap_oob 0f b6 0c 18
-
     [-,%rcx]            v533 = sload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f be 0c 18
     [-,%rcx]            v534 = sload8_complex.i32 v521+v522         ; bin: heap_oob 0f be 0c 18
-
     [-,%rcx]            v535 = uload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f b7 0c 18
     [-,%rcx]            v536 = uload16_complex.i32 v521+v522         ; bin: heap_oob 0f b7 0c 18
-
     [-,%rcx]            v537 = sload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f bf 0c 18
     [-,%rcx]            v538 = sload16_complex.i32 v521+v522         ; bin: heap_oob 0f bf 0c 18
-
     [-,%rcx]            v539 = uload32_complex v521+v522             ; bin: heap_oob 8b 0c 18
     [-,%rcx]            v540 = sload32_complex v521+v522             ; bin: heap_oob 48 63 0c 18
 
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
+    [-,%rcx]            v601 = iconst.i32 1
     store_complex v600, v521+v522        ; bin: heap_oob 48 89 0c 18
     store_complex v600, v521+v522+1      ; bin: heap_oob 48 89 4c 18 01
     store_complex v600, v521+v522+0x1000 ; bin: heap_oob 48 89 8c 18 00001000
-    [-,%rcx]            v601 = iconst.i32 1
     store_complex v601, v521+v522        ; bin: heap_oob 89 0c 18
     store_complex v601, v521+v522+1      ; bin: heap_oob 89 4c 18 01
     store_complex v601, v521+v522+0x1000 ; bin: heap_oob 89 8c 18 00001000
-
+    istore32_complex v600, v521+v522     ; bin: heap_oob 89 0c 18
+    istore16_complex v600, v521+v522     ; bin: heap_oob 66 48 89 0c 18
+    istore16_complex v601, v521+v522     ; bin: heap_oob 66 89 0c 18
+    istore8_complex v600, v521+v522      ; bin: heap_oob 88 0c 18
+    istore8_complex v601, v521+v522      ; bin: heap_oob 88 0c 18
 
     ; asm: testq %rcx, %rcx
     ; asm: je ebb1

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -611,6 +611,21 @@ ebb0:
     [-,%rcx]            v529 = load_complex.i64 v521+v522+0x1000  ; bin: heap_oob 48 8b 8c 18 00001000
     [-,%rcx]            v530 = load_complex.i32 v521+v522+0x1000  ; bin: heap_oob 8b 8c 18 00001000
 
+    [-,%rcx]            v531 = uload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f b6 0c 18
+    [-,%rcx]            v532 = uload8_complex.i32 v521+v522         ; bin: heap_oob 0f b6 0c 18
+
+    [-,%rcx]            v533 = sload8_complex.i64 v521+v522         ; bin: heap_oob 48 0f be 0c 18
+    [-,%rcx]            v534 = sload8_complex.i32 v521+v522         ; bin: heap_oob 0f be 0c 18
+
+    [-,%rcx]            v535 = uload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f b7 0c 18
+    [-,%rcx]            v536 = uload16_complex.i32 v521+v522         ; bin: heap_oob 0f b7 0c 18
+
+    [-,%rcx]            v537 = sload16_complex.i64 v521+v522         ; bin: heap_oob 48 0f bf 0c 18
+    [-,%rcx]            v538 = sload16_complex.i32 v521+v522         ; bin: heap_oob 0f bf 0c 18
+
+    [-,%rcx]            v539 = uload32_complex v521+v522             ; bin: heap_oob 8b 0c 18
+    [-,%rcx]            v540 = sload32_complex v521+v522             ; bin: heap_oob 48 63 0c 18
+
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
     store_complex v600, v521+v522        ; bin: heap_oob 48 89 0c 18

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -633,6 +633,10 @@ ebb0:
     ; asm: movslq (%rax,%rbx,1),%rcx
     [-,%rcx]            v540 = sload32_complex v521+v522             ; bin: heap_oob 48 63 0c 18
 
+    [-,%r13]            v550 = iconst.i64 1
+    [-,%r14]            v551 = iconst.i64 1
+    [-,%r12]            v552 = load_complex.i32 v550+v551            ; bin: heap_oob 47 8b 64 35 00
+
     ; Store Complex
     [-,%rcx]            v600 = iconst.i64 1
     [-,%rcx]            v601 = iconst.i32 1

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -594,6 +594,17 @@ ebb0:
     [-,%r8]              v520 = ushr_imm v4, 63   ; bin: 49 c1 e8 3f
 
 
+    ; Load/Store Complex
+    [-,%rax]            v521 = iconst.i64 1
+    [-,%rbx]            v522 = iconst.i64 1
+    ; asm: movq (%rax,%rbx,1), %rcx
+    [-,%rcx]            v523 = load_complex.i64 v521,v522      ; bin: heap_oob 48 8b 0c 18
+    [-,%rcx]            v524 = load_complex.i32 v521,v522      ; bin: heap_oob 8b 0c 18
+    [-,%rcx]            v525 = load_complex.i64 v521,v522+1    ; bin: heap_oob 48 8b 4c 18 01
+    [-,%rcx]            v526 = load_complex.i32 v521,v522+1    ; bin: heap_oob 8b 4c 18 01
+
+
+
     ; asm: testq %rcx, %rcx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 48 85 c9 74 1b

--- a/filetests/parser/tiny.cton
+++ b/filetests/parser/tiny.cton
@@ -158,9 +158,11 @@ ebb0(v1: i32):
     v6 = load.i64 aligned notrap v1
     v7 = load.i64 v1-12
     v8 = load.i64 notrap v1+0x1_0000
+    v9 = load_complex.i64 v1, v2+0x1
     store v2, v1
     store aligned v3, v1+12
     store notrap aligned v3, v1-12
+    store_complex v3, v1, v2+0x1
 }
 ; sameln: function %memory(i32) fast {
 ; nextln: ebb0(v1: i32):
@@ -171,9 +173,11 @@ ebb0(v1: i32):
 ; nextln:     v6 = load.i64 notrap aligned v1
 ; nextln:     v7 = load.i64 v1-12
 ; nextln:     v8 = load.i64 notrap v1+0x0001_0000
+; nextln:     v9 = load_complex.i64 v1, v2+1
 ; nextln:     store v2, v1
 ; nextln:     store aligned v3, v1+12
 ; nextln:     store notrap aligned v3, v1-12
+; nextln:     store_complex v3, v1, v2+1
 
 ; Register diversions.
 ; This test file has no ISA, so we can unly use register unit numbers.

--- a/filetests/parser/tiny.cton
+++ b/filetests/parser/tiny.cton
@@ -158,11 +158,12 @@ ebb0(v1: i32):
     v6 = load.i64 aligned notrap v1
     v7 = load.i64 v1-12
     v8 = load.i64 notrap v1+0x1_0000
-    v9 = load_complex.i64 v1, v2+0x1
+    v9 = load_complex.i64 v1+v2
+    v10 = load_complex.i64 v1+v2+0x1
     store v2, v1
     store aligned v3, v1+12
     store notrap aligned v3, v1-12
-    store_complex v3, v1, v2+0x1
+    store_complex v3, v1+v2+0x1
 }
 ; sameln: function %memory(i32) fast {
 ; nextln: ebb0(v1: i32):
@@ -173,11 +174,12 @@ ebb0(v1: i32):
 ; nextln:     v6 = load.i64 notrap aligned v1
 ; nextln:     v7 = load.i64 v1-12
 ; nextln:     v8 = load.i64 notrap v1+0x0001_0000
-; nextln:     v9 = load_complex.i64 v1, v2+1
+; nextln:     v9 = load_complex.i64 v1+v2
+; nextln:     v10 = load_complex.i64 v1+v2+1
 ; nextln:     store v2, v1
 ; nextln:     store aligned v3, v1+12
 ; nextln:     store notrap aligned v3, v1-12
-; nextln:     store_complex v3, v1, v2+1
+; nextln:     store_complex v3, v1+v2+1
 
 ; Register diversions.
 ; This test file has no ISA, so we can unly use register unit numbers.

--- a/filetests/parser/tiny.cton
+++ b/filetests/parser/tiny.cton
@@ -163,6 +163,7 @@ ebb0(v1: i32):
     store v2, v1
     store aligned v3, v1+12
     store notrap aligned v3, v1-12
+    store_complex v3, v1+v2
     store_complex v3, v1+v2+0x1
 }
 ; sameln: function %memory(i32) fast {
@@ -179,6 +180,7 @@ ebb0(v1: i32):
 ; nextln:     store v2, v1
 ; nextln:     store aligned v3, v1+12
 ; nextln:     store notrap aligned v3, v1-12
+; nextln:     store_complex v3, v1+v2
 ; nextln:     store_complex v3, v1+v2+1
 
 ; Register diversions.

--- a/filetests/postopt/complex_memory_ops.cton
+++ b/filetests/postopt/complex_memory_ops.cton
@@ -53,3 +53,43 @@ ebb0(v0: i64, v1: i64):
 ; nextln:    v10 = sload32_complex v0+v1+1
 ; nextln:    return v10
 ; nextln: }
+
+function %dual_stores(i64, i64, i64) {
+ebb0(v0: i64, v1: i64, v2: i64):
+[RexOp1rr#8001]    v3 = iadd v0, v1
+[RexOp1st#8089]    store.i64 v2, v3
+[RexOp1st#88]      istore8.i64 v2, v3
+[RexMp1st#189]     istore16.i64 v2, v3
+[RexOp1st#89]      istore32.i64 v2, v3
+[Op1ret#c3]        return
+}
+
+; sameln: function %dual_stores
+; nextln: ebb0(v0: i64, v1: i64, v2: i64):
+; nextln:    v3 = iadd v0, v1
+; nextln:    store_complex v2, v0+v1
+; nextln:    istore8_complex v2, v0+v1
+; nextln:    istore16_complex v2, v0+v1
+; nextln:    istore32_complex v2, v0+v1
+; nextln:    return
+; nextln: }
+
+function %dual_stores2(i64, i64, i64) {
+ebb0(v0: i64, v1: i64, v2: i64):
+[RexOp1rr#8001]         v3 = iadd v0, v1
+[RexOp1stDisp8#8089]    store.i64 v2, v3+1
+[RexOp1stDisp8#88]      istore8.i64 v2, v3+1
+[RexMp1stDisp8#189]     istore16.i64 v2, v3+1
+[RexOp1stDisp8#89]      istore32.i64 v2, v3+1
+[Op1ret#c3]             return
+}
+
+; sameln: function %dual_stores2
+; nextln: ebb0(v0: i64, v1: i64, v2: i64):
+; nextln:    v3 = iadd v0, v1
+; nextln:    store_complex v2, v0+v1+1
+; nextln:    istore8_complex v2, v0+v1+1
+; nextln:    istore16_complex v2, v0+v1+1
+; nextln:    istore32_complex v2, v0+v1+1
+; nextln:    return
+; nextln: }

--- a/filetests/postopt/complex_memory_ops.cton
+++ b/filetests/postopt/complex_memory_ops.cton
@@ -1,0 +1,17 @@
+test postopt
+set is_64bit
+isa x86
+
+function %basic_load(i64, i64) -> i64 {
+ebb0(v0: i64, v1: i64):
+[RexOp1rr#8001]    v3 = iadd v0, v1
+[RexOp1ld#808b]    v4 = load.i64 v3 
+[Op1ret#c3]        return v4
+}
+
+; sameln: function %basic_load
+; nextln: ebb0(v0: i64, v1: i64):
+; nextln:    v3 = iadd v0, v1
+; nextln:    v4 = load_complex.i64 v0+v1
+; nextln:    return v4
+; nextln: }

--- a/filetests/postopt/complex_memory_ops.cton
+++ b/filetests/postopt/complex_memory_ops.cton
@@ -2,16 +2,54 @@ test postopt
 set is_64bit
 isa x86
 
-function %basic_load(i64, i64) -> i64 {
+function %dual_loads(i64, i64) -> i64 {
 ebb0(v0: i64, v1: i64):
 [RexOp1rr#8001]    v3 = iadd v0, v1
-[RexOp1ld#808b]    v4 = load.i64 v3 
-[Op1ret#c3]        return v4
+                   v4 = load.i64 v3
+                   v5 = uload8.i64 v3
+                   v6 = sload8.i64 v3
+                   v7 = uload16.i64 v3
+                   v8 = sload16.i64 v3
+                   v9 = uload32.i64 v3
+                   v10 = sload32.i64 v3
+[Op1ret#c3]        return v10
 }
 
-; sameln: function %basic_load
+; sameln: function %dual_loads
 ; nextln: ebb0(v0: i64, v1: i64):
 ; nextln:    v3 = iadd v0, v1
 ; nextln:    v4 = load_complex.i64 v0+v1
-; nextln:    return v4
+; nextln:    v5 = uload8_complex.i64 v0+v1
+; nextln:    v6 = sload8_complex.i64 v0+v1
+; nextln:    v7 = uload16_complex.i64 v0+v1
+; nextln:    v8 = sload16_complex.i64 v0+v1
+; nextln:    v9 = uload32_complex v0+v1
+; nextln:    v10 = sload32_complex v0+v1
+; nextln:    return v10
+; nextln: }
+
+function %dual_loads2(i64, i64) -> i64 {
+ebb0(v0: i64, v1: i64):
+[RexOp1rr#8001]    v3 = iadd v0, v1
+                   v4 = load.i64 v3+1
+                   v5 = uload8.i64 v3+1
+                   v6 = sload8.i64 v3+1
+                   v7 = uload16.i64 v3+1
+                   v8 = sload16.i64 v3+1
+                   v9 = uload32.i64 v3+1
+                   v10 = sload32.i64 v3+1
+[Op1ret#c3]        return v10
+}
+
+; sameln: function %dual_loads2
+; nextln: ebb0(v0: i64, v1: i64):
+; nextln:    v3 = iadd v0, v1
+; nextln:    v4 = load_complex.i64 v0+v1+1
+; nextln:    v5 = uload8_complex.i64 v0+v1+1
+; nextln:    v6 = sload8_complex.i64 v0+v1+1
+; nextln:    v7 = uload16_complex.i64 v0+v1+1
+; nextln:    v8 = sload16_complex.i64 v0+v1+1
+; nextln:    v9 = uload32_complex v0+v1+1
+; nextln:    v10 = sload32_complex v0+v1+1
+; nextln:    return v10
 ; nextln: }

--- a/lib/codegen/meta/base/formats.py
+++ b/lib/codegen/meta/base/formats.py
@@ -57,7 +57,9 @@ CallIndirect = InstructionFormat(sig_ref, VALUE, VARIABLE_ARGS)
 FuncAddr = InstructionFormat(func_ref)
 
 Load = InstructionFormat(memflags, VALUE, offset32)
+LoadComplex = InstructionFormat(memflags, VARIABLE_ARGS, offset32)
 Store = InstructionFormat(memflags, VALUE, VALUE, offset32)
+StoreComplex = InstructionFormat(memflags, VALUE, VARIABLE_ARGS, offset32)
 
 StackLoad = InstructionFormat(stack_slot, offset32)
 StackStore = InstructionFormat(VALUE, stack_slot, offset32)

--- a/lib/codegen/meta/base/instructions.py
+++ b/lib/codegen/meta/base/instructions.py
@@ -257,7 +257,7 @@ load = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
-loadComplex = Instruction(
+load_complex = Instruction(
     'load_complex', r"""
     """,
     ins=(Flags, args, Offset), outs=a, can_load=True)
@@ -271,7 +271,7 @@ store = Instruction(
         """,
         ins=(Flags, x, p, Offset), can_store=True)
 
-storeComplex = Instruction(
+store_complex = Instruction(
     'store_complex', r"""
     """,
     ins=(Flags, x, args, Offset), can_store=True)

--- a/lib/codegen/meta/base/instructions.py
+++ b/lib/codegen/meta/base/instructions.py
@@ -291,6 +291,11 @@ uload8 = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+uload8_complex = Instruction(
+    'uload8_complex', r"""
+    """,
+    ins=(Flags, args, Offset), outs=a, can_load=True)
+
 sload8 = Instruction(
         'sload8', r"""
         Load 8 bits from memory at ``p + Offset`` and sign-extend.
@@ -299,6 +304,11 @@ sload8 = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+sload8_complex = Instruction(
+    'sload8_complex', r"""
+    """,
+    ins=(Flags, args, Offset), outs=a, can_load=True)
+
 istore8 = Instruction(
         'istore8', r"""
         Store the low 8 bits of ``x`` to memory at ``p + Offset``.
@@ -306,6 +316,11 @@ istore8 = Instruction(
         This is equivalent to ``ireduce.i8`` followed by ``store.i8``.
         """,
         ins=(Flags, x, p, Offset), can_store=True)
+
+istore8_complex = Instruction(
+        'istore8_complex', r"""
+        """,
+        ins=(Flags, x, args, Offset), can_store=True)
 
 iExt16 = TypeVar(
         'iExt16', 'An integer type with more than 16 bits',
@@ -321,6 +336,11 @@ uload16 = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+uload16_complex = Instruction(
+        'uload16_complex', r"""
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
+
 sload16 = Instruction(
         'sload16', r"""
         Load 16 bits from memory at ``p + Offset`` and sign-extend.
@@ -329,6 +349,11 @@ sload16 = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+sload16_complex = Instruction(
+        'sload16_complex', r"""
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
+
 istore16 = Instruction(
         'istore16', r"""
         Store the low 16 bits of ``x`` to memory at ``p + Offset``.
@@ -336,6 +361,11 @@ istore16 = Instruction(
         This is equivalent to ``ireduce.i16`` followed by ``store.i16``.
         """,
         ins=(Flags, x, p, Offset), can_store=True)
+
+istore16_complex = Instruction(
+        'istore16_complex', r"""
+        """,
+        ins=(Flags, x, args, Offset), can_store=True)
 
 iExt32 = TypeVar(
         'iExt32', 'An integer type with more than 32 bits',
@@ -351,6 +381,11 @@ uload32 = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+uload32_complex = Instruction(
+        'uload32_complex', r"""
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
+
 sload32 = Instruction(
         'sload32', r"""
         Load 32 bits from memory at ``p + Offset`` and sign-extend.
@@ -359,6 +394,11 @@ sload32 = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+sload32_complex = Instruction(
+        'sload32_complex', r"""
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
+
 istore32 = Instruction(
         'istore32', r"""
         Store the low 32 bits of ``x`` to memory at ``p + Offset``.
@@ -366,6 +406,11 @@ istore32 = Instruction(
         This is equivalent to ``ireduce.i32`` followed by ``store.i32``.
         """,
         ins=(Flags, x, p, Offset), can_store=True)
+
+istore32_complex = Instruction(
+        'istore32_complex', r"""
+        """,
+        ins=(Flags, x, args, Offset), can_store=True)
 
 x = Operand('x', Mem, doc='Value to be stored')
 a = Operand('a', Mem, doc='Value loaded')

--- a/lib/codegen/meta/base/instructions.py
+++ b/lib/codegen/meta/base/instructions.py
@@ -246,6 +246,7 @@ x = Operand('x', Mem, doc='Value to be stored')
 a = Operand('a', Mem, doc='Value loaded')
 p = Operand('p', iAddr)
 Flags = Operand('Flags', memflags)
+args = Operand('args', VARIABLE_ARGS, doc='Address arguments')
 
 load = Instruction(
         'load', r"""
@@ -256,6 +257,11 @@ load = Instruction(
         """,
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
+loadComplex = Instruction(
+    'load_complex', r"""
+    """,
+    ins=(Flags, args, Offset), outs=a, can_load=True)
+
 store = Instruction(
         'store', r"""
         Store ``x`` to memory at ``p + Offset``.
@@ -264,6 +270,12 @@ store = Instruction(
         memory representation.
         """,
         ins=(Flags, x, p, Offset), can_store=True)
+
+storeComplex = Instruction(
+    'store_complex', r"""
+    """,
+    ins=(Flags, x, args, Offset), can_store=True)
+
 
 iExt8 = TypeVar(
         'iExt8', 'An integer type with more than 8 bits',

--- a/lib/codegen/meta/base/instructions.py
+++ b/lib/codegen/meta/base/instructions.py
@@ -258,9 +258,13 @@ load = Instruction(
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
 load_complex = Instruction(
-    'load_complex', r"""
-    """,
-    ins=(Flags, args, Offset), outs=a, can_load=True)
+        'load_complex', r"""
+        Load from memory at ``sum(args) + Offset``.
+
+        This is a polymorphic instruction that can load any value type which
+        has a memory representation.
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
 
 store = Instruction(
         'store', r"""
@@ -272,9 +276,13 @@ store = Instruction(
         ins=(Flags, x, p, Offset), can_store=True)
 
 store_complex = Instruction(
-    'store_complex', r"""
-    """,
-    ins=(Flags, x, args, Offset), can_store=True)
+        'store_complex', r"""
+        Store ``x`` to memory at ``sum(args) + Offset``.
+
+        This is a polymorphic instruction that can store any value type with a
+        memory representation.
+        """,
+        ins=(Flags, x, args, Offset), can_store=True)
 
 
 iExt8 = TypeVar(
@@ -292,9 +300,12 @@ uload8 = Instruction(
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
 uload8_complex = Instruction(
-    'uload8_complex', r"""
-    """,
-    ins=(Flags, args, Offset), outs=a, can_load=True)
+        'uload8_complex', r"""
+        Load 8 bits from memory at ``sum(args) + Offset`` and zero-extend.
+
+        This is equivalent to ``load.i8`` followed by ``uextend``.
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
 
 sload8 = Instruction(
         'sload8', r"""
@@ -305,9 +316,12 @@ sload8 = Instruction(
         ins=(Flags, p, Offset), outs=a, can_load=True)
 
 sload8_complex = Instruction(
-    'sload8_complex', r"""
-    """,
-    ins=(Flags, args, Offset), outs=a, can_load=True)
+        'sload8_complex', r"""
+        Load 8 bits from memory at ``sum(args) + Offset`` and sign-extend.
+
+        This is equivalent to ``load.i8`` followed by ``uextend``.
+        """,
+        ins=(Flags, args, Offset), outs=a, can_load=True)
 
 istore8 = Instruction(
         'istore8', r"""
@@ -319,6 +333,9 @@ istore8 = Instruction(
 
 istore8_complex = Instruction(
         'istore8_complex', r"""
+        Store the low 8 bits of ``x`` to memory at ``sum(args) + Offset``.
+
+        This is equivalent to ``ireduce.i8`` followed by ``store.i8``.
         """,
         ins=(Flags, x, args, Offset), can_store=True)
 
@@ -338,6 +355,9 @@ uload16 = Instruction(
 
 uload16_complex = Instruction(
         'uload16_complex', r"""
+        Load 16 bits from memory at ``sum(args) + Offset`` and zero-extend.
+
+        This is equivalent to ``load.i16`` followed by ``uextend``.
         """,
         ins=(Flags, args, Offset), outs=a, can_load=True)
 
@@ -351,6 +371,9 @@ sload16 = Instruction(
 
 sload16_complex = Instruction(
         'sload16_complex', r"""
+        Load 16 bits from memory at ``sum(args) + Offset`` and sign-extend.
+
+        This is equivalent to ``load.i16`` followed by ``uextend``.
         """,
         ins=(Flags, args, Offset), outs=a, can_load=True)
 
@@ -364,6 +387,9 @@ istore16 = Instruction(
 
 istore16_complex = Instruction(
         'istore16_complex', r"""
+        Store the low 16 bits of ``x`` to memory at ``sum(args) + Offset``.
+
+        This is equivalent to ``ireduce.i16`` followed by ``store.i16``.
         """,
         ins=(Flags, x, args, Offset), can_store=True)
 
@@ -383,6 +409,9 @@ uload32 = Instruction(
 
 uload32_complex = Instruction(
         'uload32_complex', r"""
+        Load 32 bits from memory at ``sum(args) + Offset`` and zero-extend.
+
+        This is equivalent to ``load.i32`` followed by ``uextend``.
         """,
         ins=(Flags, args, Offset), outs=a, can_load=True)
 
@@ -396,6 +425,9 @@ sload32 = Instruction(
 
 sload32_complex = Instruction(
         'sload32_complex', r"""
+        Load 32 bits from memory at ``sum(args) + Offset`` and sign-extend.
+
+        This is equivalent to ``load.i32`` followed by ``uextend``.
         """,
         ins=(Flags, args, Offset), outs=a, can_load=True)
 
@@ -409,6 +441,9 @@ istore32 = Instruction(
 
 istore32_complex = Instruction(
         'istore32_complex', r"""
+        Store the low 32 bits of ``x`` to memory at ``sum(args) + Offset``.
+
+        This is equivalent to ``ireduce.i32`` followed by ``store.i32``.
         """,
         ins=(Flags, x, args, Offset), can_store=True)
 

--- a/lib/codegen/meta/base/predicates.py
+++ b/lib/codegen/meta/base/predicates.py
@@ -33,3 +33,9 @@ class IsColocatedData(FieldPredicate):
         # type: () -> None
         super(IsColocatedData, self).__init__(
             UnaryGlobalVar.global_var, 'is_colocated_data', ('func',))
+
+class LengthEquals(FieldPredicate):
+    def __init__(self, iform, num):
+        # type: (FormatField, int) -> None
+        super(LengthEquals, self).__init__(
+            iform.args(), 'has_length_of', (num, 'func'))

--- a/lib/codegen/meta/base/predicates.py
+++ b/lib/codegen/meta/base/predicates.py
@@ -2,12 +2,12 @@
 Cretonne predicates that consider `Function` fields.
 """
 from cdsl.predicates import FieldPredicate
-from .formats import UnaryGlobalVar
+from .formats import UnaryGlobalVar, InstructionFormat
 
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from cdsl.formats import FormatField  # noqa
+        from cdsl.formats import InstructionFormat, FormatField  # noqa
 except ImportError:
     pass
 
@@ -34,8 +34,9 @@ class IsColocatedData(FieldPredicate):
         super(IsColocatedData, self).__init__(
             UnaryGlobalVar.global_var, 'is_colocated_data', ('func',))
 
+
 class LengthEquals(FieldPredicate):
     def __init__(self, iform, num):
-        # type: (FormatField, int) -> None
+        # type: (InstructionFormat, int) -> None
         super(LengthEquals, self).__init__(
             iform.args(), 'has_length_of', (num, 'func'))

--- a/lib/codegen/meta/cdsl/formats.py
+++ b/lib/codegen/meta/cdsl/formats.py
@@ -105,6 +105,13 @@ class InstructionFormat(object):
 
     def args(self):
         # type: () -> FormatField
+        """
+        Provides a ValueListField, which is derived from FormatField,
+        corresponding to the full ValueList of the instruction format. This
+        is useful for creating predicates for instructions which use variadic
+        arguments.
+        """
+
         if self.has_value_list:
             return ValueListField(self)
         return None
@@ -216,7 +223,7 @@ class FormatField(object):
     This corresponds to a single member of a variant of the `InstructionData`
     data type.
 
-    :param iformat: Parent `InstructionFormat`.
+    :param iform: Parent `InstructionFormat`.
     :param immnum: Immediate operand number in parent.
     :param kind: Immediate Operand kind.
     :param member: Member name in `InstructionData` variant.
@@ -243,6 +250,14 @@ class FormatField(object):
 
 
 class ValueListField(FormatField):
+    """
+    The full value list field of an instruction format.
+
+    This corresponds to all Value-type members of a variant of the
+    `InstructionData` format, which contains a ValueList.
+
+    :param iform: Parent `InstructionFormat`.
+    """
     def __init__(self, iform):
         # type: (InstructionFormat) -> None
         self.format = iform

--- a/lib/codegen/meta/cdsl/formats.py
+++ b/lib/codegen/meta/cdsl/formats.py
@@ -103,6 +103,10 @@ class InstructionFormat(object):
         InstructionFormat._registry[sig] = self
         InstructionFormat.all_formats.append(self)
 
+    def args(self):
+        if self.has_value_list:
+            return ValueListField(self)
+
     def _process_member_names(self, kinds):
         # type: (Sequence[Union[OperandKind, Tuple[str, OperandKind]]]) -> Iterable[FormatField]  # noqa
         """
@@ -227,6 +231,17 @@ class FormatField(object):
         # type: () -> str
         return '{}.{}'.format(self.format.name, self.member)
 
+    def rust_destructuring_name(self):
+        return self.member
+
     def rust_name(self):
         # type: () -> str
         return self.member
+
+class ValueListField(FormatField):
+    def __init__(self, iform):
+        self.format = iform
+        self.member = "args"
+
+    def rust_destructuring_name(self):
+        return 'ref {}'.format(self.member)

--- a/lib/codegen/meta/cdsl/formats.py
+++ b/lib/codegen/meta/cdsl/formats.py
@@ -104,8 +104,10 @@ class InstructionFormat(object):
         InstructionFormat.all_formats.append(self)
 
     def args(self):
+        # type: () -> FormatField
         if self.has_value_list:
             return ValueListField(self)
+        return None
 
     def _process_member_names(self, kinds):
         # type: (Sequence[Union[OperandKind, Tuple[str, OperandKind]]]) -> Iterable[FormatField]  # noqa
@@ -232,16 +234,20 @@ class FormatField(object):
         return '{}.{}'.format(self.format.name, self.member)
 
     def rust_destructuring_name(self):
+        # type: () -> str
         return self.member
 
     def rust_name(self):
         # type: () -> str
         return self.member
 
+
 class ValueListField(FormatField):
     def __init__(self, iform):
+        # type: (InstructionFormat) -> None
         self.format = iform
         self.member = "args"
 
     def rust_destructuring_name(self):
+        # type: () -> str
         return 'ref {}'.format(self.member)

--- a/lib/codegen/meta/cdsl/instructions.py
+++ b/lib/codegen/meta/cdsl/instructions.py
@@ -209,7 +209,7 @@ class Instruction(object):
                     self.other_typevars = self._verify_ctrl_typevar(tv)
                     self.ctrl_typevar = tv
                     self.use_typevar_operand = True
-            except RuntimeError as e:
+            except Exception as e:
                 typevar_error = e
 
         if not self.use_typevar_operand:

--- a/lib/codegen/meta/cdsl/instructions.py
+++ b/lib/codegen/meta/cdsl/instructions.py
@@ -201,15 +201,16 @@ class Instruction(object):
         # Prefer to use the typevar_operand to infer the controlling typevar.
         self.use_typevar_operand = False
         typevar_error = None
-        if self.format.typevar_operand is not None:
+        tv_op = self.format.typevar_operand
+        if tv_op is not None and tv_op < len(self.value_opnums):
             try:
-                opnum = self.value_opnums[self.format.typevar_operand]
+                opnum = self.value_opnums[tv_op]
                 tv = self.ins[opnum].typevar
                 if tv is tv.free_typevar() or tv.singleton_type() is not None:
                     self.other_typevars = self._verify_ctrl_typevar(tv)
                     self.ctrl_typevar = tv
                     self.use_typevar_operand = True
-            except Exception as e:
+            except RuntimeError as e:
                 typevar_error = e
 
         if not self.use_typevar_operand:

--- a/lib/codegen/meta/gen_binemit.py
+++ b/lib/codegen/meta/gen_binemit.py
@@ -27,7 +27,7 @@ def gen_recipe(recipe, fmt):
     nvops = iform.num_value_operands
     want_args = any(isinstance(i, RegClass) or isinstance(i, Stack)
                     for i in recipe.ins)
-    assert not want_args or nvops > 0
+    assert not want_args or nvops > 0 or iform.has_value_list
     want_outs = any(isinstance(o, RegClass) or isinstance(o, Stack)
                     for o in recipe.outs)
 

--- a/lib/codegen/meta/gen_encoding.py
+++ b/lib/codegen/meta/gen_encoding.py
@@ -103,7 +103,7 @@ def emit_instp(instp, fmt, has_func=False):
     fnames = set()  # type: Set[str]
     for p in leafs:
         if isinstance(p, FieldPredicate):
-            fnames.add(p.field.rust_name())
+            fnames.add(p.field.rust_destructuring_name())
         else:
             assert isinstance(p, TypePredicate)
             has_type_check = True

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -3,9 +3,9 @@ x86 Encodings.
 """
 from __future__ import absolute_import
 from cdsl.predicates import IsUnsignedInt, Not, And
-from base.predicates import IsColocatedFunc, IsColocatedData
+from base.predicates import IsColocatedFunc, IsColocatedData, LengthEquals
 from base import instructions as base
-from base.formats import UnaryImm, FuncAddr, Call
+from base.formats import UnaryImm, FuncAddr, Call, LoadComplex
 from .defs import X86_64, X86_32
 from . import recipes as r
 from . import settings as cfg
@@ -216,7 +216,7 @@ X86_64.enc(base.ctz.i32, *r.urm(0xf3, 0x0f, 0xbc), isap=cfg.use_bmi1)
 for recipe in [r.ldWithIndex, r.ldWithIndexDisp8, r.ldWithIndexDisp32]:
     enc_i32_i64(base.load_complex, recipe, 0x8b)
     enc_x86_64(base.uload32_complex, recipe, 0x8b)
-    X86_64.enc(base.sload32_complex, *recipe.rex(0x63, w=1))
+    X86_64.enc(base.sload32_complex, *recipe.rex(0x63, w=1), instp=LengthEquals(LoadComplex, 2))
     enc_i32_i64(base.uload16_complex, recipe, 0x0f, 0xb7)
     enc_i32_i64(base.sload16_complex, recipe, 0x0f, 0xbf)
     enc_i32_i64(base.uload8_complex, recipe, 0x0f, 0xb6)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from cdsl.predicates import IsUnsignedInt, Not, And
 from base.predicates import IsColocatedFunc, IsColocatedData, LengthEquals
 from base import instructions as base
-from base.formats import UnaryImm, FuncAddr, Call, LoadComplex
+from base.formats import UnaryImm, FuncAddr, Call, LoadComplex, StoreComplex
 from .defs import X86_64, X86_32
 from . import recipes as r
 from . import settings as cfg
@@ -54,6 +54,15 @@ def enc_x86_64(inst, recipe, *args, **kwargs):
     X86_64.enc(inst, *recipe(*args, **kwargs))
 
 
+def enc_x86_64_instp(inst, recipe, instp, *args, **kwargs):
+    # type: (MaybeBoundInst, r.TailRecipe, *int, **int) -> None
+    """
+    Add encodings for `inst` to X86_64 with and without a REX prefix.
+    """
+    X86_64.enc(inst, *recipe.rex(*args, **kwargs), instp=instp)
+    X86_64.enc(inst, *recipe(*args, **kwargs), instp=instp)
+
+
 def enc_both(inst, recipe, *args, **kwargs):
     # type: (MaybeBoundInst, r.TailRecipe, *int, **Any) -> None
     """
@@ -61,6 +70,15 @@ def enc_both(inst, recipe, *args, **kwargs):
     """
     X86_32.enc(inst, *recipe(*args, **kwargs))
     enc_x86_64(inst, recipe, *args, **kwargs)
+
+
+def enc_both_instp(inst, recipe, instp, *args, **kwargs):
+    # type: (MaybeBoundInst, r.TailRecipe, *int, **Any) -> None
+    """
+    Add encodings for `inst` to both X86_32 and X86_64.
+    """
+    X86_32.enc(inst, *recipe(*args, **kwargs), instp=instp)
+    enc_x86_64_instp(inst, recipe, instp, *args, **kwargs)
 
 
 def enc_i32_i64(inst, recipe, *args, **kwargs):
@@ -78,6 +96,25 @@ def enc_i32_i64(inst, recipe, *args, **kwargs):
     X86_64.enc(inst.i32, *recipe(*args, **kwargs))
 
     X86_64.enc(inst.i64, *recipe.rex(*args, w=1, **kwargs))
+
+
+def enc_i32_i64_instp(inst, recipe, instp, *args, **kwargs):
+    # type: (MaybeBoundInst, r.TailRecipe, *int, **int) -> None
+    """
+    Add encodings for `inst.i32` to X86_32.
+    Add encodings for `inst.i32` to X86_64 with and without REX.
+    Add encodings for `inst.i64` to X86_64 with a REX.W prefix.
+
+    Similar to `enc_i32_i64` but applies `instp` to each encoding.
+    """
+    X86_32.enc(inst.i32, *recipe(*args, **kwargs), instp=instp)
+
+    # REX-less encoding must come after REX encoding so we don't use it by
+    # default. Otherwise reg-alloc would never use r8 and up.
+    X86_64.enc(inst.i32, *recipe.rex(*args, **kwargs), instp=instp)
+    X86_64.enc(inst.i32, *recipe(*args, **kwargs), instp=instp)
+
+    X86_64.enc(inst.i64, *recipe.rex(*args, w=1, **kwargs), instp=instp)
 
 
 def enc_i32_i64_ld_st(inst, w_bit, recipe, *args, **kwargs):
@@ -213,26 +250,28 @@ X86_64.enc(base.ctz.i32, *r.urm(0xf3, 0x0f, 0xbc), isap=cfg.use_bmi1)
 # Loads and stores.
 #
 
+ldcomplexp = LengthEquals(LoadComplex, 2)
 for recipe in [r.ldWithIndex, r.ldWithIndexDisp8, r.ldWithIndexDisp32]:
-    enc_i32_i64(base.load_complex, recipe, 0x8b)
-    enc_x86_64(base.uload32_complex, recipe, 0x8b)
+    enc_i32_i64_instp(base.load_complex, recipe, ldcomplexp, 0x8b)
+    enc_x86_64_instp(base.uload32_complex, recipe, ldcomplexp, 0x8b)
     X86_64.enc(base.sload32_complex, *recipe.rex(0x63, w=1),
-               instp=LengthEquals(LoadComplex, 2))
-    enc_i32_i64(base.uload16_complex, recipe, 0x0f, 0xb7)
-    enc_i32_i64(base.sload16_complex, recipe, 0x0f, 0xbf)
-    enc_i32_i64(base.uload8_complex, recipe, 0x0f, 0xb6)
-    enc_i32_i64(base.sload8_complex, recipe, 0x0f, 0xbe)
+               instp=ldcomplexp)
+    enc_i32_i64_instp(base.uload16_complex, recipe, ldcomplexp, 0x0f, 0xb7)
+    enc_i32_i64_instp(base.sload16_complex, recipe, ldcomplexp, 0x0f, 0xbf)
+    enc_i32_i64_instp(base.uload8_complex, recipe, ldcomplexp, 0x0f, 0xb6)
+    enc_i32_i64_instp(base.sload8_complex, recipe, ldcomplexp, 0x0f, 0xbe)
 
+stcomplexp = LengthEquals(StoreComplex, 3)
 for recipe in [r.stWithIndex, r.stWithIndexDisp8, r.stWithIndexDisp32]:
-    enc_i32_i64(base.store_complex, recipe, 0x89)
-    enc_x86_64(base.istore32_complex, recipe, 0x89)
-    enc_i32_i64(base.istore16_complex, recipe, 0x66, 0x89)
+    enc_i32_i64_instp(base.store_complex, recipe, stcomplexp, 0x89)
+    enc_x86_64_instp(base.istore32_complex, recipe, stcomplexp, 0x89)
+    enc_i32_i64_instp(base.istore16_complex, recipe, stcomplexp, 0x66, 0x89)
 
 for recipe in [r.stWithIndex_abcd,
                r.stWithIndexDisp8_abcd,
                r.stWithIndexDisp32_abcd]:
-    enc_both(base.istore8_complex.i32, recipe, 0x88)
-    enc_x86_64(base.istore8_complex.i64, recipe, 0x88)
+    enc_both_instp(base.istore8_complex.i32, recipe, stcomplexp, 0x88)
+    enc_x86_64_instp(base.istore8_complex.i64, recipe, stcomplexp, 0x88)
 
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -224,6 +224,12 @@ for recipe in [r.ldWithIndex, r.ldWithIndexDisp8, r.ldWithIndexDisp32]:
 
 for recipe in [r.stWithIndex, r.stWithIndexDisp8, r.stWithIndexDisp32]:
     enc_i32_i64(base.store_complex, recipe, 0x89)
+    enc_x86_64(base.istore32_complex, recipe, 0x89)
+    enc_i32_i64(base.istore16_complex, recipe, 0x66, 0x89)
+
+for recipe in [r.stWithIndex_abcd, r.stWithIndexDisp8_abcd, r.stWithIndexDisp32_abcd]:
+    enc_both(base.istore8_complex.i32, recipe, 0x88)
+    enc_x86_64(base.istore8_complex.i64, recipe, 0x88)
 
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -55,7 +55,7 @@ def enc_x86_64(inst, recipe, *args, **kwargs):
 
 
 def enc_x86_64_instp(inst, recipe, instp, *args, **kwargs):
-    # type: (MaybeBoundInst, r.TailRecipe, *int, **int) -> None
+    # type: (MaybeBoundInst, r.TailRecipe, FieldPredicate, *int, **int) -> None
     """
     Add encodings for `inst` to X86_64 with and without a REX prefix.
     """
@@ -73,7 +73,7 @@ def enc_both(inst, recipe, *args, **kwargs):
 
 
 def enc_both_instp(inst, recipe, instp, *args, **kwargs):
-    # type: (MaybeBoundInst, r.TailRecipe, *int, **Any) -> None
+    # type: (MaybeBoundInst, r.TailRecipe, FieldPredicate, *int, **Any) -> None
     """
     Add encodings for `inst` to both X86_32 and X86_64.
     """
@@ -99,7 +99,7 @@ def enc_i32_i64(inst, recipe, *args, **kwargs):
 
 
 def enc_i32_i64_instp(inst, recipe, instp, *args, **kwargs):
-    # type: (MaybeBoundInst, r.TailRecipe, *int, **int) -> None
+    # type: (MaybeBoundInst, r.TailRecipe, FieldPredicate, *int, **int) -> None
     """
     Add encodings for `inst.i32` to X86_32.
     Add encodings for `inst.i32` to X86_64 with and without REX.

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -213,17 +213,9 @@ X86_64.enc(base.ctz.i32, *r.urm(0xf3, 0x0f, 0xbc), isap=cfg.use_bmi1)
 # Loads and stores.
 #
 
-X86_64.enc(base.load_complex.i64, *r.ldWithIndex.rex(0x8b, w=1))
-X86_64.enc(base.load_complex.i32, *r.ldWithIndex.rex(0x8b))
-X86_64.enc(base.load_complex.i32, *r.ldWithIndex(0x8b))
-
-X86_64.enc(base.load_complex.i64, *r.ldWithIndexDisp8.rex(0x8b, w=1))
-X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp8.rex(0x8b))
-X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp8(0x8b))
-
-X86_64.enc(base.load_complex.i64, *r.ldWithIndexDisp32.rex(0x8b, w=1))
-X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp32.rex(0x8b))
-X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp32(0x8b))
+enc_i32_i64(base.load_complex, r.ldWithIndex, 0x8b)
+enc_i32_i64(base.load_complex, r.ldWithIndexDisp8, 0x8b)
+enc_i32_i64(base.load_complex, r.ldWithIndexDisp32, 0x8b)
 
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -266,7 +266,8 @@ stcomplexp = LengthEquals(StoreComplex, 3)
 for recipe in [r.stWithIndex, r.stWithIndexDisp8, r.stWithIndexDisp32]:
     enc_i32_i64_instp(base.store_complex, recipe, stcomplexp, 0x89)
     enc_x86_64_instp(base.istore32_complex, recipe, stcomplexp, 0x89)
-    enc_i32_i64_instp(base.istore16_complex, recipe, stcomplexp, 0x66, 0x89)
+    enc_both_instp(base.istore16_complex.i32, recipe, stcomplexp, 0x66, 0x89)
+    enc_x86_64_instp(base.istore16_complex.i64, recipe, stcomplexp, 0x66, 0x89)
 
 for recipe in [r.stWithIndex_abcd,
                r.stWithIndexDisp8_abcd,

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -216,7 +216,8 @@ X86_64.enc(base.ctz.i32, *r.urm(0xf3, 0x0f, 0xbc), isap=cfg.use_bmi1)
 for recipe in [r.ldWithIndex, r.ldWithIndexDisp8, r.ldWithIndexDisp32]:
     enc_i32_i64(base.load_complex, recipe, 0x8b)
     enc_x86_64(base.uload32_complex, recipe, 0x8b)
-    X86_64.enc(base.sload32_complex, *recipe.rex(0x63, w=1), instp=LengthEquals(LoadComplex, 2))
+    X86_64.enc(base.sload32_complex, *recipe.rex(0x63, w=1),
+               instp=LengthEquals(LoadComplex, 2))
     enc_i32_i64(base.uload16_complex, recipe, 0x0f, 0xb7)
     enc_i32_i64(base.sload16_complex, recipe, 0x0f, 0xbf)
     enc_i32_i64(base.uload8_complex, recipe, 0x0f, 0xb6)
@@ -227,7 +228,9 @@ for recipe in [r.stWithIndex, r.stWithIndexDisp8, r.stWithIndexDisp32]:
     enc_x86_64(base.istore32_complex, recipe, 0x89)
     enc_i32_i64(base.istore16_complex, recipe, 0x66, 0x89)
 
-for recipe in [r.stWithIndex_abcd, r.stWithIndexDisp8_abcd, r.stWithIndexDisp32_abcd]:
+for recipe in [r.stWithIndex_abcd,
+               r.stWithIndexDisp8_abcd,
+               r.stWithIndexDisp32_abcd]:
     enc_both(base.istore8_complex.i32, recipe, 0x88)
     enc_x86_64(base.istore8_complex.i64, recipe, 0x88)
 

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -212,6 +212,15 @@ X86_64.enc(base.ctz.i32, *r.urm(0xf3, 0x0f, 0xbc), isap=cfg.use_bmi1)
 #
 # Loads and stores.
 #
+
+X86_64.enc(base.load_complex.i64, *r.ldWithIndex.rex(0x8b, w=1))
+X86_64.enc(base.load_complex.i32, *r.ldWithIndex.rex(0x8b))
+X86_64.enc(base.load_complex.i32, *r.ldWithIndex(0x8b))
+
+X86_64.enc(base.load_complex.i64, *r.ldWithIndexDisp8.rex(0x8b, w=1))
+X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp8.rex(0x8b))
+X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp8(0x8b))
+
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)
     enc_x86_64(base.istore32.i64.any, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -213,13 +213,17 @@ X86_64.enc(base.ctz.i32, *r.urm(0xf3, 0x0f, 0xbc), isap=cfg.use_bmi1)
 # Loads and stores.
 #
 
-enc_i32_i64(base.load_complex, r.ldWithIndex, 0x8b)
-enc_i32_i64(base.load_complex, r.ldWithIndexDisp8, 0x8b)
-enc_i32_i64(base.load_complex, r.ldWithIndexDisp32, 0x8b)
+for recipe in [r.ldWithIndex, r.ldWithIndexDisp8, r.ldWithIndexDisp32]:
+    enc_i32_i64(base.load_complex, recipe, 0x8b)
+    enc_x86_64(base.uload32_complex, recipe, 0x8b)
+    X86_64.enc(base.sload32_complex, *recipe.rex(0x63, w=1))
+    enc_i32_i64(base.uload16_complex, recipe, 0x0f, 0xb7)
+    enc_i32_i64(base.sload16_complex, recipe, 0x0f, 0xbf)
+    enc_i32_i64(base.uload8_complex, recipe, 0x0f, 0xb6)
+    enc_i32_i64(base.sload8_complex, recipe, 0x0f, 0xbe)
 
-enc_i32_i64(base.store_complex, r.stWithIndex, 0x89)
-enc_i32_i64(base.store_complex, r.stWithIndexDisp8, 0x89)
-enc_i32_i64(base.store_complex, r.stWithIndexDisp32, 0x89)
+for recipe in [r.stWithIndex, r.stWithIndexDisp8, r.stWithIndexDisp32]:
+    enc_i32_i64(base.store_complex, recipe, 0x89)
 
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -308,17 +308,33 @@ enc_both(base.load.f32.any, r.fld, 0xf3, 0x0f, 0x10)
 enc_both(base.load.f32.any, r.fldDisp8, 0xf3, 0x0f, 0x10)
 enc_both(base.load.f32.any, r.fldDisp32, 0xf3, 0x0f, 0x10)
 
+enc_both(base.load_complex.f32, r.fldWithIndex, 0xf3, 0x0f, 0x10)
+enc_both(base.load_complex.f32, r.fldWithIndexDisp8, 0xf3, 0x0f, 0x10)
+enc_both(base.load_complex.f32, r.fldWithIndexDisp32, 0xf3, 0x0f, 0x10)
+
 enc_both(base.load.f64.any, r.fld, 0xf2, 0x0f, 0x10)
 enc_both(base.load.f64.any, r.fldDisp8, 0xf2, 0x0f, 0x10)
 enc_both(base.load.f64.any, r.fldDisp32, 0xf2, 0x0f, 0x10)
+
+enc_both(base.load_complex.f64, r.fldWithIndex, 0xf2, 0x0f, 0x10)
+enc_both(base.load_complex.f64, r.fldWithIndexDisp8, 0xf2, 0x0f, 0x10)
+enc_both(base.load_complex.f64, r.fldWithIndexDisp32, 0xf2, 0x0f, 0x10)
 
 enc_both(base.store.f32.any, r.fst, 0xf3, 0x0f, 0x11)
 enc_both(base.store.f32.any, r.fstDisp8, 0xf3, 0x0f, 0x11)
 enc_both(base.store.f32.any, r.fstDisp32, 0xf3, 0x0f, 0x11)
 
+enc_both(base.store_complex.f32, r.fstWithIndex, 0xf3, 0x0f, 0x11)
+enc_both(base.store_complex.f32, r.fstWithIndexDisp8, 0xf3, 0x0f, 0x11)
+enc_both(base.store_complex.f32, r.fstWithIndexDisp32, 0xf3, 0x0f, 0x11)
+
 enc_both(base.store.f64.any, r.fst, 0xf2, 0x0f, 0x11)
 enc_both(base.store.f64.any, r.fstDisp8, 0xf2, 0x0f, 0x11)
 enc_both(base.store.f64.any, r.fstDisp32, 0xf2, 0x0f, 0x11)
+
+enc_both(base.store_complex.f64, r.fstWithIndex, 0xf2, 0x0f, 0x11)
+enc_both(base.store_complex.f64, r.fstWithIndexDisp8, 0xf2, 0x0f, 0x11)
+enc_both(base.store_complex.f64, r.fstWithIndexDisp32, 0xf2, 0x0f, 0x11)
 
 enc_both(base.fill.f32, r.ffillSib32, 0xf3, 0x0f, 0x10)
 enc_both(base.regfill.f32, r.fregfill32, 0xf3, 0x0f, 0x10)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -217,6 +217,10 @@ enc_i32_i64(base.load_complex, r.ldWithIndex, 0x8b)
 enc_i32_i64(base.load_complex, r.ldWithIndexDisp8, 0x8b)
 enc_i32_i64(base.load_complex, r.ldWithIndexDisp32, 0x8b)
 
+enc_i32_i64(base.store_complex, r.stWithIndex, 0x89)
+enc_i32_i64(base.store_complex, r.stWithIndexDisp8, 0x89)
+enc_i32_i64(base.store_complex, r.stWithIndexDisp32, 0x89)
+
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)
     enc_x86_64(base.istore32.i64.any, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -221,6 +221,10 @@ X86_64.enc(base.load_complex.i64, *r.ldWithIndexDisp8.rex(0x8b, w=1))
 X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp8.rex(0x8b))
 X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp8(0x8b))
 
+X86_64.enc(base.load_complex.i64, *r.ldWithIndexDisp32.rex(0x8b, w=1))
+X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp32.rex(0x8b))
+X86_64.enc(base.load_complex.i32, *r.ldWithIndexDisp32(0x8b))
+
 for recipe in [r.st, r.stDisp8, r.stDisp32]:
     enc_i32_i64_ld_st(base.store, True, recipe, 0x89)
     enc_x86_64(base.istore32.i64.any, recipe, 0x89)

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -930,7 +930,23 @@ ldWithIndexDisp8 = TailRecipe(
     let offset: i32 = offset.into();
     sink.put1(offset as u8);
     ''')
-    
+
+ldWithIndexDisp32 = TailRecipe(
+    'ldWithIndexDisp32', LoadComplex, size=6, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(GPR),
+    instp=IsSignedInt(LoadComplex.offset, 32),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg0, out_reg0, in_reg1), sink);
+    modrm_sib_disp32(out_reg0, sink);
+    sib(0, in_reg1, in_reg0, sink);
+    let offset: i32 = offset.into();
+    sink.put4(offset as u32);
+    ''')
+
 
 # XX /r load with no offset.
 ld = TailRecipe(

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -740,7 +740,7 @@ st = TailRecipe(
 
 stWithIndex = TailRecipe(
     'stWithIndex', StoreComplex, size=2,
-    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsEqual(StoreComplex.offset, 0),
     clobbers_flags=False,
@@ -770,7 +770,7 @@ st_abcd = TailRecipe(
 
 stWithIndex_abcd = TailRecipe(
     'stWithIndex_abcd', StoreComplex, size=2,
-    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(ABCD, GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsEqual(StoreComplex.offset, 0),
     clobbers_flags=False,
@@ -798,7 +798,7 @@ fst = TailRecipe(
 
 fstWithIndex = TailRecipe(
         'fstWithIndex', StoreComplex, size=2,
-        ins=(FPR, GPR_ZERO_DEREF_SAFE, GPR_ZERO_DEREF_SAFE), outs=(),
+        ins=(FPR, GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE), outs=(),
         instp=IsEqual(StoreComplex.offset, 0),
         clobbers_flags=False,
         emit='''
@@ -827,7 +827,7 @@ stDisp8 = TailRecipe(
 
 stWithIndexDisp8 = TailRecipe(
     'stWithIndexDisp8', StoreComplex, size=3,
-    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 8),
     clobbers_flags=False,
@@ -859,7 +859,7 @@ stDisp8_abcd = TailRecipe(
 
 stWithIndexDisp8_abcd = TailRecipe(
     'stWithIndexDisp8_abcd', StoreComplex, size=3,
-    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(ABCD, GPR, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 8),
     clobbers_flags=False,
@@ -890,7 +890,7 @@ fstDisp8 = TailRecipe(
 
 fstWithIndexDisp8 = TailRecipe(
     'fstWithIndexDisp8', StoreComplex, size=3,
-    ins=(FPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(FPR, GPR, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 8),
     clobbers_flags=False,
@@ -921,7 +921,7 @@ stDisp32 = TailRecipe(
 
 stWithIndexDisp32 = TailRecipe(
     'stWithIndexDisp32', StoreComplex, size=6,
-    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 32),
     clobbers_flags=False,
@@ -952,7 +952,7 @@ stDisp32_abcd = TailRecipe(
 
 stWithIndexDisp32_abcd = TailRecipe(
     'stWithIndexDisp32_abcd', StoreComplex, size=6,
-    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(ABCD, GPR, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 32),
     clobbers_flags=False,
@@ -982,7 +982,7 @@ fstDisp32 = TailRecipe(
 
 fstWithIndexDisp32 = TailRecipe(
     'fstWithIndexDisp32', StoreComplex, size=6,
-    ins=(FPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(FPR, GPR, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 32),
     clobbers_flags=False,
@@ -1065,7 +1065,7 @@ ld = TailRecipe(
         ''')
 
 ldWithIndex = TailRecipe(
-    'ldWithIndex', LoadComplex, size=2, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'ldWithIndex', LoadComplex, size=2, ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(GPR),
     instp=IsEqual(LoadComplex.offset, 0),
     clobbers_flags=False,
@@ -1092,7 +1092,7 @@ fld = TailRecipe(
         ''')
 
 fldWithIndex = TailRecipe(
-    'fldWithIndex', LoadComplex, size=2, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'fldWithIndex', LoadComplex, size=2, ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(FPR),
     instp=IsEqual(LoadComplex.offset, 0),
     clobbers_flags=False,
@@ -1122,7 +1122,7 @@ ldDisp8 = TailRecipe(
 
 ldWithIndexDisp8 = TailRecipe(
     'ldWithIndexDisp8', LoadComplex, size=3,
-    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR_DEREF_SAFE),
     outs=(GPR),
     instp=IsSignedInt(LoadComplex.offset, 8),
     clobbers_flags=False,
@@ -1154,7 +1154,7 @@ fldDisp8 = TailRecipe(
 
 fldWithIndexDisp8 = TailRecipe(
     'fldWithIndexDisp8', LoadComplex, size=3,
-    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR_DEREF_SAFE),
     outs=(FPR),
     instp=IsSignedInt(LoadComplex.offset, 8),
     clobbers_flags=False,
@@ -1186,7 +1186,7 @@ ldDisp32 = TailRecipe(
 
 ldWithIndexDisp32 = TailRecipe(
     'ldWithIndexDisp32', LoadComplex, size=6,
-    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR_DEREF_SAFE),
     outs=(GPR),
     instp=IsSignedInt(LoadComplex.offset, 32),
     clobbers_flags=False,
@@ -1218,7 +1218,7 @@ fldDisp32 = TailRecipe(
 
 fldWithIndexDisp32 = TailRecipe(
     'fldWithIndexDisp32', LoadComplex, size=6,
-    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    ins=(GPR, GPR_DEREF_SAFE),
     outs=(FPR),
     instp=IsSignedInt(LoadComplex.offset, 32),
     clobbers_flags=False,

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -726,7 +726,8 @@ got_gvaddr8 = TailRecipe(
 #
 
 stWithIndex = TailRecipe(
-    'stWithIndex', StoreComplex, size=2, ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'stWithIndex', StoreComplex, size=2,
+    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsEqual(StoreComplex.offset, 0),
     clobbers_flags=False,
@@ -740,7 +741,8 @@ stWithIndex = TailRecipe(
     ''')
 
 stWithIndexDisp8 = TailRecipe(
-    'stWithIndexDisp8', StoreComplex, size=3, ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'stWithIndexDisp8', StoreComplex, size=3,
+    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 8),
     clobbers_flags=False,
@@ -756,7 +758,8 @@ stWithIndexDisp8 = TailRecipe(
     ''')
 
 stWithIndexDisp32 = TailRecipe(
-    'stWithIndexDisp32', StoreComplex, size=6, ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'stWithIndexDisp32', StoreComplex, size=6,
+    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 32),
     clobbers_flags=False,
@@ -772,7 +775,8 @@ stWithIndexDisp32 = TailRecipe(
     ''')
 
 stWithIndex_abcd = TailRecipe(
-    'stWithIndex_abcd', StoreComplex, size=2, ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'stWithIndex_abcd', StoreComplex, size=2,
+    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsEqual(StoreComplex.offset, 0),
     clobbers_flags=False,
@@ -786,7 +790,8 @@ stWithIndex_abcd = TailRecipe(
     ''')
 
 stWithIndexDisp8_abcd = TailRecipe(
-    'stWithIndexDisp8_abcd', StoreComplex, size=3, ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'stWithIndexDisp8_abcd', StoreComplex, size=3,
+    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 8),
     clobbers_flags=False,
@@ -802,7 +807,8 @@ stWithIndexDisp8_abcd = TailRecipe(
     ''')
 
 stWithIndexDisp32_abcd = TailRecipe(
-    'stWithIndexDisp32_abcd', StoreComplex, size=6, ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'stWithIndexDisp32_abcd', StoreComplex, size=6,
+    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(),
     instp=IsSignedInt(StoreComplex.offset, 32),
     clobbers_flags=False,
@@ -816,8 +822,6 @@ stWithIndexDisp32_abcd = TailRecipe(
     let offset: i32 = offset.into();
     sink.put4(offset as u32);
     ''')
-
-
 
 # XX /r register-indirect store with no offset.
 st = TailRecipe(
@@ -1010,7 +1014,8 @@ ldWithIndex = TailRecipe(
     ''')
 
 ldWithIndexDisp8 = TailRecipe(
-    'ldWithIndexDisp8', LoadComplex, size=3, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'ldWithIndexDisp8', LoadComplex, size=3,
+    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(GPR),
     instp=IsSignedInt(LoadComplex.offset, 8),
     clobbers_flags=False,
@@ -1026,7 +1031,8 @@ ldWithIndexDisp8 = TailRecipe(
     ''')
 
 ldWithIndexDisp32 = TailRecipe(
-    'ldWithIndexDisp32', LoadComplex, size=6, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    'ldWithIndexDisp32', LoadComplex, size=6,
+    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(GPR),
     instp=IsSignedInt(LoadComplex.offset, 32),
     clobbers_flags=False,

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -725,6 +725,19 @@ got_gvaddr8 = TailRecipe(
 # Store recipes.
 #
 
+# XX /r register-indirect store with no offset.
+st = TailRecipe(
+        'st', Store, size=1, ins=(GPR, GPR_ZERO_DEREF_SAFE), outs=(),
+        instp=IsEqual(Store.offset, 0),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_rm(in_reg1, in_reg0, sink);
+        ''')
+
 stWithIndex = TailRecipe(
     'stWithIndex', StoreComplex, size=2,
     ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
@@ -739,6 +752,78 @@ stWithIndex = TailRecipe(
     modrm_sib(in_reg0, sink);
     sib(0, in_reg2, in_reg1, sink);
     ''')
+
+# XX /r register-indirect store with no offset.
+# Only ABCD allowed for stored value. This is for byte stores with no REX.
+st_abcd = TailRecipe(
+        'st_abcd', Store, size=1, ins=(ABCD, GPR), outs=(),
+        instp=IsEqual(Store.offset, 0),
+        when_prefixed=st,
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_rm(in_reg1, in_reg0, sink);
+        ''')
+
+stWithIndex_abcd = TailRecipe(
+    'stWithIndex_abcd', StoreComplex, size=2,
+    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsEqual(StoreComplex.offset, 0),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    ''')
+
+# XX /r register-indirect store of FPR with no offset.
+fst = TailRecipe(
+        'fst', Store, size=1, ins=(FPR, GPR_ZERO_DEREF_SAFE), outs=(),
+        instp=IsEqual(Store.offset, 0),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_rm(in_reg1, in_reg0, sink);
+        ''')
+
+fstWithIndex = TailRecipe(
+        'fstWithIndex', StoreComplex, size=2,
+        ins=(FPR, GPR_ZERO_DEREF_SAFE, GPR_ZERO_DEREF_SAFE), outs=(),
+        instp=IsEqual(StoreComplex.offset, 0),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+        modrm_sib(in_reg0, sink);
+        sib(0, in_reg2, in_reg1, sink);
+        ''')
+
+# XX /r register-indirect store with 8-bit offset.
+stDisp8 = TailRecipe(
+        'stDisp8', Store, size=2, ins=(GPR, GPR_DEREF_SAFE), outs=(),
+        instp=IsSignedInt(Store.offset, 8),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_disp8(in_reg1, in_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put1(offset as u8);
+        ''')
 
 stWithIndexDisp8 = TailRecipe(
     'stWithIndexDisp8', StoreComplex, size=3,
@@ -757,37 +842,20 @@ stWithIndexDisp8 = TailRecipe(
     sink.put1(offset as u8);
     ''')
 
-stWithIndexDisp32 = TailRecipe(
-    'stWithIndexDisp32', StoreComplex, size=6,
-    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
-    outs=(),
-    instp=IsSignedInt(StoreComplex.offset, 32),
-    clobbers_flags=False,
-    emit='''
-    if !flags.notrap() {
-        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-    }
-    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
-    modrm_sib_disp32(in_reg0, sink);
-    sib(0, in_reg2, in_reg1, sink);
-    let offset: i32 = offset.into();
-    sink.put4(offset as u32);
-    ''')
-
-stWithIndex_abcd = TailRecipe(
-    'stWithIndex_abcd', StoreComplex, size=2,
-    ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
-    outs=(),
-    instp=IsEqual(StoreComplex.offset, 0),
-    clobbers_flags=False,
-    emit='''
-    if !flags.notrap() {
-        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-    }
-    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
-    modrm_sib(in_reg0, sink);
-    sib(0, in_reg2, in_reg1, sink);
-    ''')
+stDisp8_abcd = TailRecipe(
+        'stDisp8_abcd', Store, size=2, ins=(ABCD, GPR), outs=(),
+        instp=IsSignedInt(Store.offset, 8),
+        when_prefixed=stDisp8,
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_disp8(in_reg1, in_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put1(offset as u8);
+        ''')
 
 stWithIndexDisp8_abcd = TailRecipe(
     'stWithIndexDisp8_abcd', StoreComplex, size=3,
@@ -806,6 +874,82 @@ stWithIndexDisp8_abcd = TailRecipe(
     sink.put1(offset as u8);
     ''')
 
+fstDisp8 = TailRecipe(
+        'fstDisp8', Store, size=2, ins=(FPR, GPR_DEREF_SAFE), outs=(),
+        instp=IsSignedInt(Store.offset, 8),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_disp8(in_reg1, in_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put1(offset as u8);
+        ''')
+
+fstWithIndexDisp8 = TailRecipe(
+    'fstWithIndexDisp8', StoreComplex, size=3,
+    ins=(FPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsSignedInt(StoreComplex.offset, 8),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib_disp8(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    let offset: i32 = offset.into();
+    sink.put1(offset as u8);
+    ''')
+
+# XX /r register-indirect store with 32-bit offset.
+stDisp32 = TailRecipe(
+        'stDisp32', Store, size=5, ins=(GPR, GPR_DEREF_SAFE), outs=(),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_disp32(in_reg1, in_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put4(offset as u32);
+        ''')
+
+stWithIndexDisp32 = TailRecipe(
+    'stWithIndexDisp32', StoreComplex, size=6,
+    ins=(GPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsSignedInt(StoreComplex.offset, 32),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib_disp32(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    let offset: i32 = offset.into();
+    sink.put4(offset as u32);
+    ''')
+
+stDisp32_abcd = TailRecipe(
+        'stDisp32_abcd', Store, size=5, ins=(ABCD, GPR), outs=(),
+        when_prefixed=stDisp32,
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
+        modrm_disp32(in_reg1, in_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put4(offset as u32);
+        ''')
+
 stWithIndexDisp32_abcd = TailRecipe(
     'stWithIndexDisp32_abcd', StoreComplex, size=6,
     ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
@@ -823,115 +967,6 @@ stWithIndexDisp32_abcd = TailRecipe(
     sink.put4(offset as u32);
     ''')
 
-# XX /r register-indirect store with no offset.
-st = TailRecipe(
-        'st', Store, size=1, ins=(GPR, GPR_ZERO_DEREF_SAFE), outs=(),
-        instp=IsEqual(Store.offset, 0),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_rm(in_reg1, in_reg0, sink);
-        ''')
-
-# XX /r register-indirect store with no offset.
-# Only ABCD allowed for stored value. This is for byte stores with no REX.
-st_abcd = TailRecipe(
-        'st_abcd', Store, size=1, ins=(ABCD, GPR), outs=(),
-        instp=IsEqual(Store.offset, 0),
-        when_prefixed=st,
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_rm(in_reg1, in_reg0, sink);
-        ''')
-
-# XX /r register-indirect store of FPR with no offset.
-fst = TailRecipe(
-        'fst', Store, size=1, ins=(FPR, GPR_ZERO_DEREF_SAFE), outs=(),
-        instp=IsEqual(Store.offset, 0),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_rm(in_reg1, in_reg0, sink);
-        ''')
-
-# XX /r register-indirect store with 8-bit offset.
-stDisp8 = TailRecipe(
-        'stDisp8', Store, size=2, ins=(GPR, GPR_DEREF_SAFE), outs=(),
-        instp=IsSignedInt(Store.offset, 8),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_disp8(in_reg1, in_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put1(offset as u8);
-        ''')
-stDisp8_abcd = TailRecipe(
-        'stDisp8_abcd', Store, size=2, ins=(ABCD, GPR), outs=(),
-        instp=IsSignedInt(Store.offset, 8),
-        when_prefixed=stDisp8,
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_disp8(in_reg1, in_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put1(offset as u8);
-        ''')
-fstDisp8 = TailRecipe(
-        'fstDisp8', Store, size=2, ins=(FPR, GPR_DEREF_SAFE), outs=(),
-        instp=IsSignedInt(Store.offset, 8),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_disp8(in_reg1, in_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put1(offset as u8);
-        ''')
-
-# XX /r register-indirect store with 32-bit offset.
-stDisp32 = TailRecipe(
-        'stDisp32', Store, size=5, ins=(GPR, GPR_DEREF_SAFE), outs=(),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_disp32(in_reg1, in_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put4(offset as u32);
-        ''')
-stDisp32_abcd = TailRecipe(
-        'stDisp32_abcd', Store, size=5, ins=(ABCD, GPR), outs=(),
-        when_prefixed=stDisp32,
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
-        modrm_disp32(in_reg1, in_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put4(offset as u32);
-        ''')
 fstDisp32 = TailRecipe(
         'fstDisp32', Store, size=5, ins=(FPR, GPR_DEREF_SAFE), outs=(),
         clobbers_flags=False,
@@ -944,6 +979,23 @@ fstDisp32 = TailRecipe(
         let offset: i32 = offset.into();
         sink.put4(offset as u32);
         ''')
+
+fstWithIndexDisp32 = TailRecipe(
+    'fstWithIndexDisp32', StoreComplex, size=6,
+    ins=(FPR, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsSignedInt(StoreComplex.offset, 32),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib_disp32(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    let offset: i32 = offset.into();
+    sink.put4(offset as u32);
+    ''')
 
 # Unary spill with SIB and 32-bit displacement.
 spillSib32 = TailRecipe(
@@ -999,6 +1051,19 @@ fregspill32 = TailRecipe(
 # Load recipes
 #
 
+# XX /r load with no offset.
+ld = TailRecipe(
+        'ld', Load, size=1, ins=(GPR_ZERO_DEREF_SAFE), outs=(GPR),
+        instp=IsEqual(Load.offset, 0),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
+        modrm_rm(in_reg0, out_reg0, sink);
+        ''')
+
 ldWithIndex = TailRecipe(
     'ldWithIndex', LoadComplex, size=2, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(GPR),
@@ -1012,6 +1077,48 @@ ldWithIndex = TailRecipe(
     modrm_sib(out_reg0, sink);
     sib(0, in_reg1, in_reg0, sink);
     ''')
+
+# XX /r float load with no offset.
+fld = TailRecipe(
+        'fld', Load, size=1, ins=(GPR_ZERO_DEREF_SAFE), outs=(FPR),
+        instp=IsEqual(Load.offset, 0),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
+        modrm_rm(in_reg0, out_reg0, sink);
+        ''')
+
+fldWithIndex = TailRecipe(
+    'fldWithIndex', LoadComplex, size=2, ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(FPR),
+    instp=IsEqual(LoadComplex.offset, 0),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg0, out_reg0, in_reg1), sink);
+    modrm_sib(out_reg0, sink);
+    sib(0, in_reg1, in_reg0, sink);
+    ''')
+
+# XX /r load with 8-bit offset.
+ldDisp8 = TailRecipe(
+        'ldDisp8', Load, size=2, ins=(GPR_DEREF_SAFE), outs=(GPR),
+        instp=IsSignedInt(Load.offset, 8),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
+        modrm_disp8(in_reg0, out_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put1(offset as u8);
+        ''')
 
 ldWithIndexDisp8 = TailRecipe(
     'ldWithIndexDisp8', LoadComplex, size=3,
@@ -1030,6 +1137,53 @@ ldWithIndexDisp8 = TailRecipe(
     sink.put1(offset as u8);
     ''')
 
+# XX /r float load with 8-bit offset.
+fldDisp8 = TailRecipe(
+        'fldDisp8', Load, size=2, ins=(GPR_DEREF_SAFE), outs=(FPR),
+        instp=IsSignedInt(Load.offset, 8),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
+        modrm_disp8(in_reg0, out_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put1(offset as u8);
+        ''')
+
+fldWithIndexDisp8 = TailRecipe(
+    'fldWithIndexDisp8', LoadComplex, size=3,
+    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(FPR),
+    instp=IsSignedInt(LoadComplex.offset, 8),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg0, out_reg0, in_reg1), sink);
+    modrm_sib_disp8(out_reg0, sink);
+    sib(0, in_reg1, in_reg0, sink);
+    let offset: i32 = offset.into();
+    sink.put1(offset as u8);
+    ''')
+
+# XX /r load with 32-bit offset.
+ldDisp32 = TailRecipe(
+        'ldDisp32', Load, size=5, ins=(GPR_DEREF_SAFE), outs=(GPR),
+        instp=IsSignedInt(Load.offset, 32),
+        clobbers_flags=False,
+        emit='''
+        if !flags.notrap() {
+            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+        }
+        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
+        modrm_disp32(in_reg0, out_reg0, sink);
+        let offset: i32 = offset.into();
+        sink.put4(offset as u32);
+        ''')
+
 ldWithIndexDisp32 = TailRecipe(
     'ldWithIndexDisp32', LoadComplex, size=6,
     ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
@@ -1047,77 +1201,6 @@ ldWithIndexDisp32 = TailRecipe(
     sink.put4(offset as u32);
     ''')
 
-# XX /r load with no offset.
-ld = TailRecipe(
-        'ld', Load, size=1, ins=(GPR_ZERO_DEREF_SAFE), outs=(GPR),
-        instp=IsEqual(Load.offset, 0),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        modrm_rm(in_reg0, out_reg0, sink);
-        ''')
-
-# XX /r float load with no offset.
-fld = TailRecipe(
-        'fld', Load, size=1, ins=(GPR_ZERO_DEREF_SAFE), outs=(FPR),
-        instp=IsEqual(Load.offset, 0),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        modrm_rm(in_reg0, out_reg0, sink);
-        ''')
-
-# XX /r load with 8-bit offset.
-ldDisp8 = TailRecipe(
-        'ldDisp8', Load, size=2, ins=(GPR_DEREF_SAFE), outs=(GPR),
-        instp=IsSignedInt(Load.offset, 8),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        modrm_disp8(in_reg0, out_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put1(offset as u8);
-        ''')
-
-# XX /r float load with 8-bit offset.
-fldDisp8 = TailRecipe(
-        'fldDisp8', Load, size=2, ins=(GPR_DEREF_SAFE), outs=(FPR),
-        instp=IsSignedInt(Load.offset, 8),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        modrm_disp8(in_reg0, out_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put1(offset as u8);
-        ''')
-
-# XX /r load with 32-bit offset.
-ldDisp32 = TailRecipe(
-        'ldDisp32', Load, size=5, ins=(GPR_DEREF_SAFE), outs=(GPR),
-        instp=IsSignedInt(Load.offset, 32),
-        clobbers_flags=False,
-        emit='''
-        if !flags.notrap() {
-            sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
-        }
-        PUT_OP(bits, rex2(in_reg0, out_reg0), sink);
-        modrm_disp32(in_reg0, out_reg0, sink);
-        let offset: i32 = offset.into();
-        sink.put4(offset as u32);
-        ''')
-
 # XX /r float load with 32-bit offset.
 fldDisp32 = TailRecipe(
         'fldDisp32', Load, size=5, ins=(GPR_DEREF_SAFE), outs=(FPR),
@@ -1132,6 +1215,23 @@ fldDisp32 = TailRecipe(
         let offset: i32 = offset.into();
         sink.put4(offset as u32);
         ''')
+
+fldWithIndexDisp32 = TailRecipe(
+    'fldWithIndexDisp32', LoadComplex, size=6,
+    ins=(GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(FPR),
+    instp=IsSignedInt(LoadComplex.offset, 32),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg0, out_reg0, in_reg1), sink);
+    modrm_sib_disp32(out_reg0, sink);
+    sib(0, in_reg1, in_reg0, sink);
+    let offset: i32 = offset.into();
+    sink.put4(offset as u32);
+    ''')
 
 # Unary fill with SIB and 32-bit displacement.
 fillSib32 = TailRecipe(

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -1083,7 +1083,8 @@ ld = TailRecipe(
 
 # XX /r load with index and no offset.
 ldWithIndex = TailRecipe(
-    'ldWithIndex', LoadComplex, size=2, ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
+    'ldWithIndex', LoadComplex, size=2,
+    ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(GPR),
     instp=IsEqual(LoadComplex.offset, 0),
     clobbers_flags=False,
@@ -1111,7 +1112,8 @@ fld = TailRecipe(
 
 # XX /r float load with index and no offset.
 fldWithIndex = TailRecipe(
-    'fldWithIndex', LoadComplex, size=2, ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
+    'fldWithIndex', LoadComplex, size=2,
+    ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(FPR),
     instp=IsEqual(LoadComplex.offset, 0),
     clobbers_flags=False,

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -738,6 +738,7 @@ st = TailRecipe(
         modrm_rm(in_reg1, in_reg0, sink);
         ''')
 
+# XX /r register-indirect store with index and no offset.
 stWithIndex = TailRecipe(
     'stWithIndex', StoreComplex, size=2,
     ins=(GPR, GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
@@ -768,6 +769,8 @@ st_abcd = TailRecipe(
         modrm_rm(in_reg1, in_reg0, sink);
         ''')
 
+# XX /r register-indirect store with index and no offset.
+# Only ABCD allowed for stored value. This is for byte stores with no REX.
 stWithIndex_abcd = TailRecipe(
     'stWithIndex_abcd', StoreComplex, size=2,
     ins=(ABCD, GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
@@ -795,7 +798,7 @@ fst = TailRecipe(
         PUT_OP(bits, rex2(in_reg1, in_reg0), sink);
         modrm_rm(in_reg1, in_reg0, sink);
         ''')
-
+# XX /r register-indirect store with index and no offset of FPR.
 fstWithIndex = TailRecipe(
         'fstWithIndex', StoreComplex, size=2,
         ins=(FPR, GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE), outs=(),
@@ -825,6 +828,7 @@ stDisp8 = TailRecipe(
         sink.put1(offset as u8);
         ''')
 
+# XX /r register-indirect store with index and 8-bit offset.
 stWithIndexDisp8 = TailRecipe(
     'stWithIndexDisp8', StoreComplex, size=3,
     ins=(GPR, GPR, GPR_DEREF_SAFE),
@@ -842,6 +846,8 @@ stWithIndexDisp8 = TailRecipe(
     sink.put1(offset as u8);
     ''')
 
+# XX /r register-indirect store with 8-bit offset.
+# Only ABCD allowed for stored value. This is for byte stores with no REX.
 stDisp8_abcd = TailRecipe(
         'stDisp8_abcd', Store, size=2, ins=(ABCD, GPR), outs=(),
         instp=IsSignedInt(Store.offset, 8),
@@ -857,6 +863,8 @@ stDisp8_abcd = TailRecipe(
         sink.put1(offset as u8);
         ''')
 
+# XX /r register-indirect store with index and 8-bit offset.
+# Only ABCD allowed for stored value. This is for byte stores with no REX.
 stWithIndexDisp8_abcd = TailRecipe(
     'stWithIndexDisp8_abcd', StoreComplex, size=3,
     ins=(ABCD, GPR, GPR_DEREF_SAFE),
@@ -874,6 +882,7 @@ stWithIndexDisp8_abcd = TailRecipe(
     sink.put1(offset as u8);
     ''')
 
+# XX /r register-indirect store with 8-bit offset of FPR.
 fstDisp8 = TailRecipe(
         'fstDisp8', Store, size=2, ins=(FPR, GPR_DEREF_SAFE), outs=(),
         instp=IsSignedInt(Store.offset, 8),
@@ -888,6 +897,7 @@ fstDisp8 = TailRecipe(
         sink.put1(offset as u8);
         ''')
 
+# XX /r register-indirect store with index and 8-bit offset of FPR.
 fstWithIndexDisp8 = TailRecipe(
     'fstWithIndexDisp8', StoreComplex, size=3,
     ins=(FPR, GPR, GPR_DEREF_SAFE),
@@ -919,6 +929,7 @@ stDisp32 = TailRecipe(
         sink.put4(offset as u32);
         ''')
 
+# XX /r register-indirect store with index and 32-bit offset.
 stWithIndexDisp32 = TailRecipe(
     'stWithIndexDisp32', StoreComplex, size=6,
     ins=(GPR, GPR, GPR_DEREF_SAFE),
@@ -936,6 +947,8 @@ stWithIndexDisp32 = TailRecipe(
     sink.put4(offset as u32);
     ''')
 
+# XX /r register-indirect store with 32-bit offset.
+# Only ABCD allowed for stored value. This is for byte stores with no REX.
 stDisp32_abcd = TailRecipe(
         'stDisp32_abcd', Store, size=5, ins=(ABCD, GPR), outs=(),
         when_prefixed=stDisp32,
@@ -950,6 +963,8 @@ stDisp32_abcd = TailRecipe(
         sink.put4(offset as u32);
         ''')
 
+# XX /r register-indirect store with index and 32-bit offset.
+# Only ABCD allowed for stored value. This is for byte stores with no REX.
 stWithIndexDisp32_abcd = TailRecipe(
     'stWithIndexDisp32_abcd', StoreComplex, size=6,
     ins=(ABCD, GPR, GPR_DEREF_SAFE),
@@ -967,6 +982,7 @@ stWithIndexDisp32_abcd = TailRecipe(
     sink.put4(offset as u32);
     ''')
 
+# XX /r register-indirect store with 32-bit offset of FPR.
 fstDisp32 = TailRecipe(
         'fstDisp32', Store, size=5, ins=(FPR, GPR_DEREF_SAFE), outs=(),
         clobbers_flags=False,
@@ -980,6 +996,7 @@ fstDisp32 = TailRecipe(
         sink.put4(offset as u32);
         ''')
 
+# XX /r register-indirect store with index and 32-bit offset of FPR.
 fstWithIndexDisp32 = TailRecipe(
     'fstWithIndexDisp32', StoreComplex, size=6,
     ins=(FPR, GPR, GPR_DEREF_SAFE),
@@ -1064,6 +1081,7 @@ ld = TailRecipe(
         modrm_rm(in_reg0, out_reg0, sink);
         ''')
 
+# XX /r load with index and no offset.
 ldWithIndex = TailRecipe(
     'ldWithIndex', LoadComplex, size=2, ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(GPR),
@@ -1091,6 +1109,7 @@ fld = TailRecipe(
         modrm_rm(in_reg0, out_reg0, sink);
         ''')
 
+# XX /r float load with index and no offset.
 fldWithIndex = TailRecipe(
     'fldWithIndex', LoadComplex, size=2, ins=(GPR_ZERO_DEREF_SAFE, GPR_DEREF_SAFE),
     outs=(FPR),
@@ -1120,6 +1139,7 @@ ldDisp8 = TailRecipe(
         sink.put1(offset as u8);
         ''')
 
+# XX /r load with index and 8-bit offset.
 ldWithIndexDisp8 = TailRecipe(
     'ldWithIndexDisp8', LoadComplex, size=3,
     ins=(GPR, GPR_DEREF_SAFE),
@@ -1152,6 +1172,7 @@ fldDisp8 = TailRecipe(
         sink.put1(offset as u8);
         ''')
 
+# XX /r float load with 8-bit offset.
 fldWithIndexDisp8 = TailRecipe(
     'fldWithIndexDisp8', LoadComplex, size=3,
     ins=(GPR, GPR_DEREF_SAFE),
@@ -1184,6 +1205,7 @@ ldDisp32 = TailRecipe(
         sink.put4(offset as u32);
         ''')
 
+# XX /r load with index and 32-bit offset.
 ldWithIndexDisp32 = TailRecipe(
     'ldWithIndexDisp32', LoadComplex, size=6,
     ins=(GPR, GPR_DEREF_SAFE),
@@ -1216,6 +1238,7 @@ fldDisp32 = TailRecipe(
         sink.put4(offset as u32);
         ''')
 
+# XX /r float load with index and 32-bit offset.
 fldWithIndexDisp32 = TailRecipe(
     'fldWithIndexDisp32', LoadComplex, size=6,
     ins=(GPR, GPR_DEREF_SAFE),

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -771,6 +771,52 @@ stWithIndexDisp32 = TailRecipe(
     sink.put4(offset as u32);
     ''')
 
+stWithIndex_abcd = TailRecipe(
+    'stWithIndex_abcd', StoreComplex, size=2, ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsEqual(StoreComplex.offset, 0),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    ''')
+
+stWithIndexDisp8_abcd = TailRecipe(
+    'stWithIndexDisp8_abcd', StoreComplex, size=3, ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsSignedInt(StoreComplex.offset, 8),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib_disp8(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    let offset: i32 = offset.into();
+    sink.put1(offset as u8);
+    ''')
+
+stWithIndexDisp32_abcd = TailRecipe(
+    'stWithIndexDisp32_abcd', StoreComplex, size=6, ins=(ABCD, GPR_DEREF_SAFE, GPR_DEREF_SAFE),
+    outs=(),
+    instp=IsSignedInt(StoreComplex.offset, 32),
+    clobbers_flags=False,
+    emit='''
+    if !flags.notrap() {
+        sink.trap(TrapCode::HeapOutOfBounds, func.srclocs[inst]);
+    }
+    PUT_OP(bits, rex3(in_reg1, in_reg0, in_reg2), sink);
+    modrm_sib_disp32(in_reg0, sink);
+    sib(0, in_reg2, in_reg1, sink);
+    let offset: i32 = offset.into();
+    sink.put4(offset as u32);
+    ''')
+
 
 
 # XX /r register-indirect store with no offset.

--- a/lib/codegen/src/isa/mod.rs
+++ b/lib/codegen/src/isa/mod.rs
@@ -162,6 +162,11 @@ pub trait TargetIsa: fmt::Display {
         false
     }
 
+    /// Does the CPU implement multi-register addressing?
+    fn uses_complex_addresses(&self) -> bool {
+        false
+    }
+
     /// Get a data structure describing the registers in this ISA.
     fn register_info(&self) -> RegInfo;
 

--- a/lib/codegen/src/isa/x86/binemit.rs
+++ b/lib/codegen/src/isa/x86/binemit.rs
@@ -223,26 +223,21 @@ fn modrm_disp32<CS: CodeSink + ?Sized>(rm: RegUnit, reg: RegUnit, sink: &mut CS)
     sink.put1(b);
 }
 
-/// Emit a mode 10 ModR/M byte indicating that a SIB byte is present.
+/// Emit a mode 00 ModR/M with a 100 RM indicating a SIB byte is present.
+fn modrm_sib<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
+    modrm_rm(0b100, reg, sink);
+}
+
+/// Emit a mode 01 ModR/M with a 100 RM indicating a SIB byte and 8-bit
+/// displacement are present.
+fn modrm_sib_disp8<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
+    modrm_disp8(0b100, reg, sink);
+}
+
+/// Emit a mode 10 ModR/M with a 100 RM indicating a SIB byte and 32-bit
+/// displacement are present.
 fn modrm_sib_disp32<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
     modrm_disp32(0b100, reg, sink);
-}
-
-/// Emit a mode 00 ModR/M with a 100 RM indicating a standard SIB
-fn modrm_sib<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
-    let reg = reg as u8 & 7;
-    let mut b = 0b00_000_100;
-    b |= reg << 3;
-    sink.put1(b);
-}
-
-/// Emit a mode 01 ModR/M with a 100 RM indicating a standard SIB and 8-bit
-/// displacement.
-fn modrm_sib_disp8<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
-    let reg = reg as u8 & 7;
-    let mut b = 0b01_000_100;
-    b |= reg << 3;
-    sink.put1(b);
 }
 
 /// Emit a SIB byte with a base register and no scale+index.

--- a/lib/codegen/src/isa/x86/binemit.rs
+++ b/lib/codegen/src/isa/x86/binemit.rs
@@ -231,7 +231,16 @@ fn modrm_sib_disp32<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
 /// Emit a mode 00 ModR/M with a 100 RM indicating a standard SIB
 fn modrm_sib<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
     let reg = reg as u8 & 7;
-    let mut b = 0b00000100;
+    let mut b = 0b00_000_100;
+    b |= reg << 3;
+    sink.put1(b);
+}
+
+/// Emit a mode 01 ModR/M with a 100 RM indicating a standard SIB and 8-bit
+/// displacement.
+fn modrm_sib_disp8<CS: CodeSink + ?Sized>(reg: RegUnit, sink: &mut CS) {
+    let reg = reg as u8 & 7;
+    let mut b = 0b01_000_100;
     b |= reg << 3;
     sink.put1(b);
 }

--- a/lib/codegen/src/isa/x86/mod.rs
+++ b/lib/codegen/src/isa/x86/mod.rs
@@ -62,6 +62,10 @@ impl TargetIsa for Isa {
         true
     }
 
+    fn uses_complex_addresses(&self) -> bool {
+        true
+    }
+
     fn register_info(&self) -> RegInfo {
         registers::INFO.clone()
     }

--- a/lib/codegen/src/postopt.rs
+++ b/lib/codegen/src/postopt.rs
@@ -185,7 +185,7 @@ struct MemOpInfo {
     add_args: Option<[Value; 2]>,
 }
 
-fn optimize_complex_memory_ops(pos: &mut EncCursor, inst: Inst, isa: &TargetIsa) {
+fn optimize_complex_addresses(pos: &mut EncCursor, inst: Inst, isa: &TargetIsa) {
     let mut info = match pos.func.dfg[inst] {
         InstructionData::Load {
             opcode,
@@ -351,7 +351,9 @@ pub fn do_postopt(func: &mut Function, isa: &TargetIsa) {
                 }
             }
 
-            optimize_complex_memory_ops(&mut pos, inst, isa);
+            if isa.uses_complex_addresses() {
+                optimize_complex_addresses(&mut pos, inst, isa);
+            }
         }
     }
 }

--- a/lib/codegen/src/postopt.rs
+++ b/lib/codegen/src/postopt.rs
@@ -174,11 +174,12 @@ fn optimize_cpu_flags(
 }
 
 
-struct LoadOpInfo {
-    ld_opcode: Opcode,
-    ld_inst: Inst,
-    ld_type: Type,
-    ld_arg: Value,
+struct MemOpInfo {
+    opcode: Opcode,
+    inst: Inst,
+    itype: Type,
+    arg: Value,
+    st_arg: Option<Value>,
     flags: MemFlags,
     offset: Offset32,
     add_args: Option<[Value; 2]>,
@@ -191,11 +192,27 @@ fn optimize_complex_memory_ops(pos: &mut EncCursor, inst: Inst, isa: &TargetIsa)
             arg,
             flags,
             offset,
-        } => LoadOpInfo {
-            ld_opcode: opcode,
-            ld_inst: inst,
-            ld_type: pos.func.dfg.ctrl_typevar(inst),
-            ld_arg: arg,
+        } => MemOpInfo {
+            opcode: opcode,
+            inst: inst,
+            itype: pos.func.dfg.ctrl_typevar(inst),
+            arg: arg,
+            st_arg: None,
+            flags: flags,
+            offset: offset,
+            add_args: None,
+        },
+        InstructionData::Store {
+            opcode,
+            args,
+            flags,
+            offset,
+        } => MemOpInfo {
+            opcode: opcode,
+            inst: inst,
+            itype: pos.func.dfg.ctrl_typevar(inst),
+            arg: args[1],
+            st_arg: Some(args[0]),
             flags: flags,
             offset: offset,
             add_args: None,
@@ -203,7 +220,7 @@ fn optimize_complex_memory_ops(pos: &mut EncCursor, inst: Inst, isa: &TargetIsa)
         _ => return,
     };
 
-    if let ValueDef::Result(result_inst, _) = pos.func.dfg.value_def(info.ld_arg) {
+    if let ValueDef::Result(result_inst, _) = pos.func.dfg.value_def(info.arg) {
         match pos.func.dfg[result_inst] {
             InstructionData::Binary { opcode, args } if opcode == Opcode::Iadd => {
                 info.add_args = Some(args.clone());
@@ -214,64 +231,96 @@ fn optimize_complex_memory_ops(pos: &mut EncCursor, inst: Inst, isa: &TargetIsa)
         return;
     }
 
-    match info.ld_opcode {
+    match info.opcode {
         Opcode::Load => {
-            pos.func.dfg.replace(info.ld_inst).load_complex(
-                info.ld_type,
+            pos.func.dfg.replace(info.inst).load_complex(
+                info.itype,
                 info.flags,
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         Opcode::Uload8 => {
-            pos.func.dfg.replace(info.ld_inst).uload8_complex(
-                info.ld_type,
+            pos.func.dfg.replace(info.inst).uload8_complex(
+                info.itype,
                 info.flags,
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         Opcode::Sload8 => {
-            pos.func.dfg.replace(info.ld_inst).sload8_complex(
-                info.ld_type,
+            pos.func.dfg.replace(info.inst).sload8_complex(
+                info.itype,
                 info.flags,
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         Opcode::Uload16 => {
-            pos.func.dfg.replace(info.ld_inst).uload16_complex(
-                info.ld_type,
+            pos.func.dfg.replace(info.inst).uload16_complex(
+                info.itype,
                 info.flags,
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         Opcode::Sload16 => {
-            pos.func.dfg.replace(info.ld_inst).sload16_complex(
-                info.ld_type,
+            pos.func.dfg.replace(info.inst).sload16_complex(
+                info.itype,
                 info.flags,
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         Opcode::Uload32 => {
-            pos.func.dfg.replace(info.ld_inst).uload32_complex(
+            pos.func.dfg.replace(info.inst).uload32_complex(
                 info.flags,
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         Opcode::Sload32 => {
-            pos.func.dfg.replace(info.ld_inst).sload32_complex(
+            pos.func.dfg.replace(info.inst).sload32_complex(
                 info.flags,
+                &info.add_args.unwrap(),
+                info.offset,
+            );
+        }
+        Opcode::Store => {
+            pos.func.dfg.replace(info.inst).store_complex(
+                info.flags,
+                info.st_arg.unwrap(),
+                &info.add_args.unwrap(),
+                info.offset,
+            );
+        }
+        Opcode::Istore8 => {
+            pos.func.dfg.replace(info.inst).istore8_complex(
+                info.flags,
+                info.st_arg.unwrap(),
+                &info.add_args.unwrap(),
+                info.offset,
+            );
+        }
+        Opcode::Istore16 => {
+            pos.func.dfg.replace(info.inst).istore16_complex(
+                info.flags,
+                info.st_arg.unwrap(),
+                &info.add_args.unwrap(),
+                info.offset,
+            );
+        }
+        Opcode::Istore32 => {
+            pos.func.dfg.replace(info.inst).istore32_complex(
+                info.flags,
+                info.st_arg.unwrap(),
                 &info.add_args.unwrap(),
                 info.offset,
             );
         }
         _ => return,
     }
-    pos.func.update_encoding(info.ld_inst, isa).is_ok();
+    pos.func.update_encoding(info.inst, isa).is_ok();
 }
 
 

--- a/lib/codegen/src/predicates.rs
+++ b/lib/codegen/src/predicates.rs
@@ -46,6 +46,11 @@ pub fn is_colocated_data(global_var: ir::GlobalVar, func: &ir::Function) -> bool
     }
 }
 
+#[allow(dead_code)]
+pub fn has_length_of(value_list: &ir::ValueList, num: usize, func: &ir::Function) -> bool {
+    value_list.len(&func.dfg.value_lists) == num
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/codegen/src/verifier/mod.rs
+++ b/lib/codegen/src/verifier/mod.rs
@@ -335,6 +335,12 @@ impl<'a> Verifier<'a> {
             RegFill { src, .. } => {
                 self.verify_stack_slot(inst, src)?;
             }
+            LoadComplex { ref args, .. } => {
+                self.verify_value_list(inst, args)?;
+            }
+            StoreComplex { ref args, .. } => {
+                self.verify_value_list(inst, args)?;
+            }
 
             // Exhaustive list so we can't forget to add new formats
             Unary { .. } |
@@ -1149,8 +1155,8 @@ impl<'a> Verifier<'a> {
 mod tests {
     use super::{Error, Verifier};
     use entity::EntityList;
-    use ir::Function;
     use ir::instructions::{InstructionData, Opcode};
+    use ir::Function;
     use settings;
 
     macro_rules! assert_err_with_msg {

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -376,7 +376,7 @@ pub fn write_operands(
             ..
         } => {
             let args = args.as_slice(pool);
-            write!(w, "{} {}{}", flags, DisplayValues(&args), offset)
+            write!(w, "{} {}{}", flags, DisplayValuesWithDelimiter(&args, '+'), offset)
         }
         Store {
             flags,
@@ -396,7 +396,7 @@ pub fn write_operands(
                 "{} {}, {}{}",
                 flags,
                 args[0],
-                DisplayValues(&args[1..]),
+                DisplayValuesWithDelimiter(&args[1..], '+'),
                 offset
             )
         }
@@ -469,6 +469,21 @@ impl<'a> fmt::Display for DisplayValues<'a> {
                 write!(f, "{}", val)?;
             } else {
                 write!(f, ", {}", val)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct DisplayValuesWithDelimiter<'a>(&'a [Value], char);
+
+impl<'a> fmt::Display for DisplayValuesWithDelimiter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result {
+        for (i, val) in self.0.iter().enumerate() {
+            if i == 0 {
+                write!(f, "{}", val)?;
+            } else {
+                write!(f, "{}{}", self.1, val)?;
             }
         }
         Ok(())

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -369,12 +369,37 @@ pub fn write_operands(
         } => write!(w, " {}, {}{}", arg, stack_slot, offset),
         HeapAddr { heap, arg, imm, .. } => write!(w, " {}, {}, {}", heap, arg, imm),
         Load { flags, arg, offset, .. } => write!(w, "{} {}{}", flags, arg, offset),
+        LoadComplex {
+            flags,
+            ref args,
+            offset,
+            ..
+        } => {
+            let args = args.as_slice(pool);
+            write!(w, "{} {}{}", flags, DisplayValues(&args), offset)
+        }
         Store {
             flags,
             args,
             offset,
             ..
         } => write!(w, "{} {}, {}{}", flags, args[0], args[1], offset),
+        StoreComplex {
+            flags,
+            ref args,
+            offset,
+            ..
+        } => {
+            let args = args.as_slice(pool);
+            write!(
+                w,
+                "{} {}, {}{}",
+                flags,
+                args[0],
+                DisplayValues(&args[1..]),
+                offset
+            )
+        }
         RegMove { arg, src, dst, .. } => {
             if let Some(isa) = isa {
                 let regs = isa.register_info();

--- a/lib/codegen/src/write.rs
+++ b/lib/codegen/src/write.rs
@@ -376,7 +376,14 @@ pub fn write_operands(
             ..
         } => {
             let args = args.as_slice(pool);
-            write!(w, "{} {}{}", flags, DisplayValuesWithDelimiter(&args, '+'), offset)
+            write!(
+                w,
+                "{} {}{}",
+                flags,
+                DisplayValuesWithDelimiter(&args, '+'),
+                offset
+            )
+
         }
         Store {
             flags,

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -22,6 +22,7 @@ pub enum Token<'a> {
     LBracket, // '['
     RBracket, // ']'
     Minus, // '-'
+    Plus, // '+'
     Comma, // ','
     Dot, // '.'
     Colon, // ':'
@@ -244,6 +245,13 @@ impl<'a> Lexer<'a> {
             }
             Some('+') => {
                 self.next_ch();
+
+                if let Some(c) = self.lookahead {
+                    // If the next character won't parse as a number, we return Token::Plus
+                    if !c.is_digit(10) && c != '.' {
+                        return token(Token::Plus, loc);
+                    }
+                }
             }
             _ => {}
         }

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -182,7 +182,7 @@ impl<'a> Lexer<'a> {
                 '.' => return true,
                 _ => {}
             }
-            if self.looking_at("NaN") || self.looking_at("Inf") || self.looking_at("sNan") {
+            if self.looking_at("NaN") || self.looking_at("Inf") || self.looking_at("sNaN") {
                 return true;
             }
         }

--- a/lib/reader/src/lexer.rs
+++ b/lib/reader/src/lexer.rs
@@ -170,6 +170,25 @@ impl<'a> Lexer<'a> {
         self.source[self.pos..].starts_with(prefix)
     }
 
+    // Starting from `lookahead`, are we looking at a number?
+    fn looking_at_numeric(&self) -> bool {
+        if let Some(c) = self.lookahead {
+            if c.is_digit(10) {
+                return true;
+            }
+            match c {
+                '-' => return true,
+                '+' => return true,
+                '.' => return true,
+                _ => {}
+            }
+            if self.looking_at("NaN") || self.looking_at("Inf") || self.looking_at("sNan") {
+                return true;
+            }
+        }
+        false
+    }
+
     // Scan a single-char token.
     fn scan_char(&mut self, tok: Token<'a>) -> Result<LocatedToken<'a>, LocatedError> {
         assert_ne!(self.lookahead, None);
@@ -235,22 +254,16 @@ impl<'a> Lexer<'a> {
         match self.lookahead {
             Some('-') => {
                 self.next_ch();
-
-                if let Some(c) = self.lookahead {
-                    // If the next character won't parse as a number, we return Token::Minus
-                    if !c.is_alphanumeric() && c != '.' {
-                        return token(Token::Minus, loc);
-                    }
+                if !self.looking_at_numeric() {
+                    // If the next characters won't parse as a number, we return Token::Minus
+                    return token(Token::Minus, loc);
                 }
             }
             Some('+') => {
                 self.next_ch();
-
-                if let Some(c) = self.lookahead {
-                    // If the next character won't parse as a number, we return Token::Plus
-                    if !c.is_digit(10) && c != '.' {
-                        return token(Token::Plus, loc);
-                    }
+                if !self.looking_at_numeric() {
+                    // If the next characters won't parse as a number, we return Token::Minus
+                    return token(Token::Plus, loc);
                 }
             }
             _ => {}

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -1870,6 +1870,24 @@ impl<'a> Parser<'a> {
         Ok(args)
     }
 
+    fn parse_value_sequence(&mut self) -> Result<VariableArgs> {
+        let mut args = VariableArgs::new();
+
+        if let Some(Token::Value(v)) = self.token() {
+            args.push(v);
+            self.consume();
+        } else {
+            return Ok(args);
+        }
+
+        while self.optional(Token::Plus) {
+            args.push(self.match_value("expected value in argument list")?);
+        }
+
+        Ok(args)
+
+    }
+
     // Parse an optional value list enclosed in parantheses.
     fn parse_opt_value_list(&mut self) -> Result<VariableArgs> {
         if !self.optional(Token::LPar) {
@@ -2267,7 +2285,7 @@ impl<'a> Parser<'a> {
             }
             InstructionFormat::LoadComplex => {
                 let flags = self.optional_memflags();
-                let args = self.parse_value_list()?;
+                let args = self.parse_value_sequence()?;
                 let offset = self.optional_offset32()?;
                 InstructionData::LoadComplex {
                     opcode,
@@ -2300,7 +2318,7 @@ impl<'a> Parser<'a> {
                     Token::Comma,
                     "expected ',' between operands",
                 )?;
-                let args = self.parse_value_list()?;
+                let args = self.parse_value_sequence()?;
                 let offset = self.optional_offset32()?;
                 InstructionData::StoreComplex {
                     opcode,

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -13,8 +13,8 @@ use cretonne_codegen::ir::{AbiParam, ArgumentExtension, ArgumentLoc, Ebb, ExtFun
                            Type, Value, ValueLoc};
 use cretonne_codegen::isa::{self, Encoding, RegUnit, TargetIsa};
 use cretonne_codegen::packed_option::ReservedValue;
-use cretonne_codegen::{settings, timing};
 use cretonne_codegen::settings::CallConv;
+use cretonne_codegen::{settings, timing};
 use error::{Error, Location, Result};
 use isaspec;
 use lexer::{self, Lexer, Token};
@@ -2265,6 +2265,17 @@ impl<'a> Parser<'a> {
                     offset,
                 }
             }
+            InstructionFormat::LoadComplex => {
+                let flags = self.optional_memflags();
+                let args = self.parse_value_list()?;
+                let offset = self.optional_offset32()?;
+                InstructionData::LoadComplex {
+                    opcode,
+                    flags,
+                    args: args.into_value_list(&[], &mut ctx.function.dfg.value_lists),
+                    offset,
+                }
+            }
             InstructionFormat::Store => {
                 let flags = self.optional_memflags();
                 let arg = self.match_value("expected SSA value operand")?;
@@ -2278,6 +2289,18 @@ impl<'a> Parser<'a> {
                     opcode,
                     flags,
                     args: [arg, addr],
+                    offset,
+                }
+            }
+
+            InstructionFormat::StoreComplex => {
+                let flags = self.optional_memflags();
+                let args = self.parse_value_list()?;
+                let offset = self.optional_offset32()?;
+                InstructionData::LoadComplex {
+                    opcode,
+                    flags,
+                    args: args.into_value_list(&[], &mut ctx.function.dfg.value_lists),
                     offset,
                 }
             }
@@ -2400,9 +2423,9 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cretonne_codegen::ir::StackSlotKind;
     use cretonne_codegen::ir::entities::AnyEntity;
     use cretonne_codegen::ir::types;
+    use cretonne_codegen::ir::StackSlotKind;
     use cretonne_codegen::ir::{ArgumentExtension, ArgumentPurpose};
     use cretonne_codegen::settings::CallConv;
     use error::Error;

--- a/lib/reader/src/parser.rs
+++ b/lib/reader/src/parser.rs
@@ -2295,12 +2295,17 @@ impl<'a> Parser<'a> {
 
             InstructionFormat::StoreComplex => {
                 let flags = self.optional_memflags();
+                let src = self.match_value("expected SSA value operand")?;
+                self.match_token(
+                    Token::Comma,
+                    "expected ',' between operands",
+                )?;
                 let args = self.parse_value_list()?;
                 let offset = self.optional_offset32()?;
-                InstructionData::LoadComplex {
+                InstructionData::StoreComplex {
                     opcode,
                     flags,
-                    args: args.into_value_list(&[], &mut ctx.function.dfg.value_lists),
+                    args: args.into_value_list(&[src], &mut ctx.function.dfg.value_lists),
                     offset,
                 }
             }


### PR DESCRIPTION
This is a work-in-progress. I'm opening it now so I have something to refer to for feedback and help. :)

This PR is intended to address #285.

Things to do:
- [x] Add base instructions
- [x] Add 8-bit, 16-bit + sign/zero-extended variants
- [x] length check the value lists given to the recipes
- [x] Adjust lexer and parser to handle `v0+v1+...` as value lists
- [x] Make it possible to emit correct ModRM, REX, and SIB bytes for these instructions
- [x] Add target encodings
- [x] Encoding tests
  - [x] x86 64
  - [x] x86 32
- [x] Post-opt pass to generate load/store_complex
- [x] Post-opt tests
- [x] Documentation