### PR TITLE
[WIP] Add extensible trap sinks to module-faerie

### DIFF
--- a/lib/faerie/Cargo.toml
+++ b/lib/faerie/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 cretonne-codegen = { path = "../codegen", version = "0.6.0" }
 cretonne-module = { path = "../module", version = "0.6.0" }
-faerie = "0.2.0"
+faerie = "0.3.0"
 goblin = "0.0.14"
 failure = "0.1.1"
 

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -1,7 +1,7 @@
 //! Defines `FaerieBackend`.
 
 use container;
-use cretonne_codegen::binemit::{Addend, CodeOffset, Reloc, RelocSink, NullTrapSink};
+use cretonne_codegen::binemit::{Addend, CodeOffset, Reloc, RelocSink, TrapSink, NullTrapSink};
 use cretonne_codegen::isa::TargetIsa;
 use cretonne_codegen::{self, binemit, ir};
 use cretonne_module::{Backend, DataContext, Linkage, ModuleNamespace, Init, DataDescription,
@@ -11,15 +11,39 @@ use faerie;
 use std::fs::File;
 use target;
 
+/// todo
+pub trait TrapManifest {
+    /// todo
+    type Sink: TrapSink;
+    /// todo
+    fn create_sink(&mut self, func_name: &str) -> Self::Sink;
+    /// todo
+    fn finalize_sink(&mut self, Self::Sink);
+}
+
+/// todo
+pub struct NullTrapManifest {}
+
+impl TrapManifest for NullTrapManifest {
+    type Sink = NullTrapSink;
+    /// todo
+    fn create_sink(&mut self, _func_name: &str) -> NullTrapSink {
+        NullTrapSink {}
+    }
+    /// todo
+    fn finalize_sink(&mut self, _sink: NullTrapSink) {}
+}
+
 /// A builder for `FaerieBackend`.
-pub struct FaerieBuilder {
+pub struct FaerieBuilder<T: TrapManifest> {
     isa: Box<TargetIsa>,
     name: String,
     format: container::Format,
     faerie_target: faerie::Target,
+    trap_manifest: T,
 }
 
-impl FaerieBuilder {
+impl<T: TrapManifest> FaerieBuilder<T> {
     /// Create a new `FaerieBuilder` using the given Cretonne target, that
     /// can be passed to
     /// [`Module::new`](cretonne_module/struct.Module.html#method.new].
@@ -31,6 +55,7 @@ impl FaerieBuilder {
         isa: Box<TargetIsa>,
         name: String,
         format: container::Format,
+        trap_manifest: T,
     ) -> Result<Self, ModuleError> {
         debug_assert!(isa.flags().is_pic(), "faerie requires PIC");
         let faerie_target = target::translate(&*isa)?;
@@ -39,23 +64,25 @@ impl FaerieBuilder {
             name,
             format,
             faerie_target,
+            trap_manifest,
         })
     }
 }
 
 /// A `FaerieBackend` implements `Backend` and emits ".o" files using the `faerie` library.
-pub struct FaerieBackend {
+pub struct FaerieBackend<T> {
     isa: Box<TargetIsa>,
     artifact: faerie::Artifact,
     format: container::Format,
+    trap_manifest: T,
 }
 
 pub struct FaerieCompiledFunction {}
 
 pub struct FaerieCompiledData {}
 
-impl Backend for FaerieBackend {
-    type Builder = FaerieBuilder;
+impl<T: TrapManifest> Backend for FaerieBackend<T> {
+    type Builder = FaerieBuilder<T>;
 
     type CompiledFunction = FaerieCompiledFunction;
     type CompiledData = FaerieCompiledData;
@@ -67,14 +94,15 @@ impl Backend for FaerieBackend {
 
     /// The returned value here provides functions for emitting object files
     /// to memory and files.
-    type Product = FaerieProduct;
+    type Product = FaerieProduct<T>;
 
     /// Create a new `FaerieBackend` using the given Cretonne target.
-    fn new(builder: FaerieBuilder) -> Self {
+    fn new(builder: FaerieBuilder<T>) -> Self {
         Self {
             isa: builder.isa,
             artifact: faerie::Artifact::new(builder.faerie_target, builder.name),
             format: builder.format,
+            trap_manifest: builder.trap_manifest,
         }
     }
 
@@ -114,7 +142,7 @@ impl Backend for FaerieBackend {
             };
             // Ignore traps for now. For now, frontends should just avoid generating code
             // that traps.
-            let mut trap_sink = NullTrapSink {};
+            let mut trap_sink = self.trap_manifest.create_sink(name);
 
             unsafe {
                 ctx.emit_to_memory(
@@ -124,6 +152,8 @@ impl Backend for FaerieBackend {
                     &mut trap_sink,
                 )
             };
+
+            self.trap_manifest.finalize_sink(trap_sink)
         }
 
         self.artifact.define(name, code).expect(
@@ -224,10 +254,11 @@ impl Backend for FaerieBackend {
         // Nothing to do.
     }
 
-    fn finish(self) -> FaerieProduct {
+    fn finish(self) -> FaerieProduct<T> {
         FaerieProduct {
             artifact: self.artifact,
             format: self.format,
+            trap_manifest: self.trap_manifest,
         }
     }
 }
@@ -235,12 +266,16 @@ impl Backend for FaerieBackend {
 /// This is the output of `Module`'s
 /// [`finish`](../cretonne_module/struct.Module.html#method.finish) function.
 /// It provides functions for writing out the object file to memory or a file.
-pub struct FaerieProduct {
-    artifact: faerie::Artifact,
-    format: container::Format,
+pub struct FaerieProduct<T> {
+    /// todo
+    pub artifact: faerie::Artifact,
+    /// todo
+    pub format: container::Format,
+    /// todo
+    pub trap_manifest: T,
 }
 
-impl FaerieProduct {
+impl<T> FaerieProduct<T> {
     /// Return the name of the output file. This is the name passed into `new`.
     pub fn name(&self) -> &str {
         &self.artifact.name
@@ -292,14 +327,14 @@ fn translate_data_linkage(linkage: Linkage, writable: bool) -> faerie::Decl {
     }
 }
 
-struct FaerieRelocSink<'a> {
+struct FaerieRelocSink<'a, T: TrapManifest + 'a> {
     format: container::Format,
     artifact: &'a mut faerie::Artifact,
     name: &'a str,
-    namespace: &'a ModuleNamespace<'a, FaerieBackend>,
+    namespace: &'a ModuleNamespace<'a, FaerieBackend<T>>,
 }
 
-impl<'a> RelocSink for FaerieRelocSink<'a> {
+impl<'a, T: TrapManifest> RelocSink for FaerieRelocSink<'a, T> {
     fn reloc_ebb(&mut self, _offset: CodeOffset, _reloc: Reloc, _ebb_offset: CodeOffset) {
         unimplemented!();
     }

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -28,5 +28,5 @@ mod backend;
 mod container;
 mod target;
 
-pub use backend::{FaerieBuilder, FaerieBackend};
+pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct};
 pub use container::Format;

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -28,5 +28,5 @@ mod backend;
 mod container;
 mod target;
 
-pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct};
+pub use backend::{FaerieBuilder, FaerieBackend, FaerieProduct, TrapManifest, NullTrapManifest};
 pub use container::Format;

--- a/lib/faerie/src/lib.rs
+++ b/lib/faerie/src/lib.rs
@@ -21,7 +21,6 @@
 extern crate cretonne_codegen;
 extern crate cretonne_module;
 extern crate faerie;
-#[macro_use]
 extern crate failure;
 extern crate goblin;
 

--- a/lib/faerie/src/target.rs
+++ b/lib/faerie/src/target.rs
@@ -1,9 +1,9 @@
 use cretonne_codegen::isa;
+use cretonne_module::ModuleError;
 use faerie::Target;
-use failure::Error;
 
 /// Translate from a Cretonne `TargetIsa` to a Faerie `Target`.
-pub fn translate(isa: &isa::TargetIsa) -> Result<Target, Error> {
+pub fn translate(isa: &isa::TargetIsa) -> Result<Target, ModuleError> {
     let name = isa.name();
     match name {
         "x86" => Ok(if isa.flags().is_64bit() {
@@ -13,6 +13,8 @@ pub fn translate(isa: &isa::TargetIsa) -> Result<Target, Error> {
         }),
         "arm32" => Ok(Target::ARMv7),
         "arm64" => Ok(Target::ARM64),
-        _ => Err(format_err!("unsupported isa: {}", name)),
+        _ => Err(ModuleError::Backend(
+            format!("unsupported faerie isa: {}", name),
+        )),
     }
 }

--- a/lib/module/Cargo.toml
+++ b/lib/module/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 cretonne-codegen = { path = "../codegen", version = "0.6.0", default-features = false }
 cretonne-entity = { path = "../entity", version = "0.6.0", default-features = false }
 hashmap_core = { version = "0.1.4", optional = true }
+failure = "0.1.1"
 
 [features]
 default = ["std"]

--- a/lib/module/src/backend.rs
+++ b/lib/module/src/backend.rs
@@ -3,9 +3,9 @@
 use DataContext;
 use Linkage;
 use ModuleNamespace;
+use ModuleError;
 use cretonne_codegen::Context;
 use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::result::CtonError;
 use cretonne_codegen::{binemit, ir};
 use std::marker;
 
@@ -57,19 +57,17 @@ where
         ctx: &Context,
         namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> Result<Self::CompiledFunction, CtonError>;
+    ) -> Result<Self::CompiledFunction, ModuleError>;
 
     /// Define a zero-initialized data object of the given size.
     ///
     /// Data objects must be declared before being defined.
-    ///
-    /// TODO: Is CtonError the right error code here?
     fn define_data(
         &mut self,
         name: &str,
         data_ctx: &DataContext,
         namespace: &ModuleNamespace<Self>,
-    ) -> Result<Self::CompiledData, CtonError>;
+    ) -> Result<Self::CompiledData, ModuleError>;
 
     /// Write the address of `what` into the data for `data` at `offset`. `data` must refer to a
     /// defined data object.

--- a/lib/module/src/data_context.rs
+++ b/lib/module/src/data_context.rs
@@ -94,7 +94,7 @@ impl DataContext {
         self.description.init = Init::Zeros { size };
     }
 
-    /// Define a zero-initialized object with the given size.
+    /// Define an object initialized with the given contents.
     ///
     /// TODO: Can we avoid a Box here?
     pub fn define(&mut self, contents: Box<[u8]>, writable: Writability) {

--- a/lib/module/src/lib.rs
+++ b/lib/module/src/lib.rs
@@ -16,9 +16,12 @@
                 use_self,
                 ))]
 
+#[macro_use]
 extern crate cretonne_codegen;
 #[macro_use]
 extern crate cretonne_entity;
+#[macro_use]
+extern crate failure;
 
 mod backend;
 mod data_context;
@@ -26,4 +29,4 @@ mod module;
 
 pub use backend::Backend;
 pub use data_context::{DataContext, Writability, DataDescription, Init};
-pub use module::{DataId, FuncId, Linkage, Module, ModuleNamespace};
+pub use module::{DataId, FuncId, FuncOrDataId, Linkage, Module, ModuleNamespace, ModuleError};

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -2,10 +2,9 @@
 
 use cretonne_codegen::binemit::{Addend, CodeOffset, Reloc, RelocSink, NullTrapSink};
 use cretonne_codegen::isa::TargetIsa;
-use cretonne_codegen::result::CtonError;
 use cretonne_codegen::{self, ir, settings};
 use cretonne_module::{Backend, DataContext, Linkage, ModuleNamespace, Writability,
-                      DataDescription, Init};
+                      DataDescription, Init, ModuleError};
 use cretonne_native;
 use std::ffi::CString;
 use std::ptr;
@@ -116,7 +115,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         ctx: &cretonne_codegen::Context,
         _namespace: &ModuleNamespace<Self>,
         code_size: u32,
-    ) -> Result<Self::CompiledFunction, CtonError> {
+    ) -> Result<Self::CompiledFunction, ModuleError> {
         let size = code_size as usize;
         let ptr = self.code_memory.allocate(size).expect(
             "TODO: handle OOM etc.",
@@ -139,7 +138,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
         _name: &str,
         data: &DataContext,
         _namespace: &ModuleNamespace<Self>,
-    ) -> Result<Self::CompiledData, CtonError> {
+    ) -> Result<Self::CompiledData, ModuleError> {
         let &DataDescription {
             writable,
             ref init,

--- a/test-no_std.sh
+++ b/test-no_std.sh
@@ -21,10 +21,10 @@ do
     cd "lib/$LIB"
 
     # Test with just "core" enabled.
-    cargo test --no-default-features --features core
+    cargo +nightly test --no-default-features --features core
 
     # Test with "core" and "std" enabled at the same time.
-    cargo test --features core
+    cargo +nightly test --features core
 
     cd "$topdir"
 done


### PR DESCRIPTION
We need to collect the trap information that is produced during code generation, and would like to use module-faerie rather than forking our own customized version.

This patch creates a trait `ModuleRegistry` that is used throughout the faerie backend. It is kind of invasive and I'm not sure if I figured out the right boundaries for the abstraction. Let me know what you think.

Based on top of #307 