### PR TITLE
windows fastcall (x64) call convention

### DIFF
--- a/filetests/isa/x86/windows_fastcall_x64.cton
+++ b/filetests/isa/x86/windows_fastcall_x64.cton
@@ -1,0 +1,34 @@
+test compile
+set is_64bit
+set opt_level=best
+set is_pic
+isa x86 haswell
+
+; check if for one arg we use the right register
+function %one_arg(i64) windows_fastcall {
+ebb0(v0: i64):
+    return
+}
+; check: function %one_arg(i64 [%rcx], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+; nextln: ss0 = incoming_arg 16, offset -48
+
+; check if we still use registers for 4 arguments
+function %four_args(i64, i64, i64, i64) windows_fastcall {
+ebb0(v0: i64, v1: i64, v2: i64, v3: i64):
+    return
+}
+; check: function %four_args(i64 [%rcx], i64 [%rdx], i64 [%r8], i64 [%r9], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+
+; check if float arguments are passed through XMM registers
+function %four_float_args(f64, f64, f64, f64) windows_fastcall {
+ebb0(v0: f64, v1: f64, v2: f64, v3: f64):
+    return
+}
+; check: function %four_float_args(f64 [%xmm0], f64 [%xmm1], f64 [%xmm2], f64 [%xmm3], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {
+
+; check if we use stack space for > 4 arguments
+function %five_args(i64, i64, i64, i64, i64) windows_fastcall {
+ebb0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
+    return
+}
+; check: function %five_args(i64 [%rcx], i64 [%rdx], i64 [%r8], i64 [%r9], i64 [32], i64 fp [%rbp]) -> i64 fp [%rbp] windows_fastcall {

--- a/lib/codegen/meta/base/settings.py
+++ b/lib/codegen/meta/base/settings.py
@@ -36,14 +36,22 @@ call_conv = EnumSetting(
         - fast: not-ABI-stable convention for best performance
         - cold: not-ABI-stable convention for infrequently executed code
         - system_v: System V-style convention used on many platforms
-        - fastcall: Windows "fastcall" convention, also used for x64 and ARM
+        - windows_fastcall: Windows "fastcall" convention, also used for
+                            x64 and ARM
         - baldrdash: SpiderMonkey WebAssembly convention
         - probestack: specialized convention for the probestack function
 
         The default calling convention may be overridden by individual
         functions.
         """,
-        'fast', 'cold', 'system_v', 'fastcall', 'baldrdash', 'probestack')
+
+        'fast',
+        'cold',
+        'system_v',
+        'windows_fastcall',
+        'baldrdash',
+        'probestack'
+)
 
 # Note that Cretonne doesn't currently need an is_pie flag, because PIE is just
 # PIC where symbols can't be pre-empted, which can be expressed with the

--- a/lib/codegen/src/ir/extfunc.rs
+++ b/lib/codegen/src/ir/extfunc.rs
@@ -382,7 +382,7 @@ mod tests {
             CallConv::Fast,
             CallConv::Cold,
             CallConv::SystemV,
-            CallConv::Fastcall,
+            CallConv::WindowsFastcall,
             CallConv::Baldrdash,
         ]
         {

--- a/lib/codegen/src/isa/x86/abi.rs
+++ b/lib/codegen/src/isa/x86/abi.rs
@@ -22,6 +22,12 @@ static ARG_GPRS: [RU; 6] = [RU::rdi, RU::rsi, RU::rdx, RU::rcx, RU::r8, RU::r9];
 /// Return value registers.
 static RET_GPRS: [RU; 3] = [RU::rax, RU::rdx, RU::rcx];
 
+/// Argument registers for x86-64, when using windows fastcall
+static ARG_GPRS_WIN_FASTCALL_X64: [RU; 4] = [RU::rcx, RU::rdx, RU::r8, RU::r9];
+
+/// Return value registers for x86-64, when using windows fastcall
+static RET_GPRS_WIN_FASTCALL_X64: [RU; 1] = [RU::rax];
+
 struct Args {
     pointer_bytes: u32,
     pointer_bits: u16,
@@ -36,6 +42,14 @@ struct Args {
 
 impl Args {
     fn new(bits: u16, gpr: &'static [RU], fpr_limit: usize, call_conv: CallConv) -> Self {
+        let offset = if let CallConv::WindowsFastcall = call_conv {
+            // [1] "The caller is responsible for allocating space for parameters to the callee,
+            // and must always allocate sufficient space to store four register parameters"
+            32
+        } else {
+            0
+        };
+
         Self {
             pointer_bytes: u32::from(bits) / 8,
             pointer_bits: bits,
@@ -44,7 +58,7 @@ impl Args {
             gpr_used: 0,
             fpr_limit,
             fpr_used: 0,
-            offset: 0,
+            offset,
             call_conv,
         }
     }
@@ -120,7 +134,11 @@ pub fn legalize_signature(sig: &mut ir::Signature, flags: &shared_settings::Flag
 
     if flags.is_64bit() {
         bits = 64;
-        args = Args::new(bits, &ARG_GPRS, 8, sig.call_conv);
+        args = if sig.call_conv == CallConv::WindowsFastcall {
+            Args::new(bits, &ARG_GPRS_WIN_FASTCALL_X64[..], 4, sig.call_conv)
+        } else {
+            Args::new(bits, &ARG_GPRS[..], 8, sig.call_conv)
+        };
     } else {
         bits = 32;
         args = Args::new(bits, &[], 0, sig.call_conv);
@@ -128,7 +146,13 @@ pub fn legalize_signature(sig: &mut ir::Signature, flags: &shared_settings::Flag
 
     legalize_args(&mut sig.params, &mut args);
 
-    let mut rets = Args::new(bits, &RET_GPRS, 2, sig.call_conv);
+    let regs = if sig.call_conv == CallConv::WindowsFastcall {
+        &RET_GPRS_WIN_FASTCALL_X64[..]
+    } else {
+        &RET_GPRS[..]
+    };
+
+    let mut rets = Args::new(bits, regs, 2, sig.call_conv);
     legalize_args(&mut sig.returns, &mut rets);
 }
 
@@ -161,7 +185,24 @@ pub fn allocatable_registers(_func: &ir::Function, flags: &shared_settings::Flag
 /// Get the set of callee-saved registers.
 fn callee_saved_gprs(flags: &shared_settings::Flags) -> &'static [RU] {
     if flags.is_64bit() {
-        &[RU::rbx, RU::r12, RU::r13, RU::r14, RU::r15]
+        if flags.call_conv() == CallConv::WindowsFastcall {
+            // "registers RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15 are considered nonvolatile
+            //  and must be saved and restored by a function that uses them."
+            // as per https://msdn.microsoft.com/en-us/library/6t169e9c.aspx
+            &[
+                RU::rbx,
+                /*RU::rbp,*/
+                RU::rdi,
+                RU::rsi,
+                /*RU::rsp,*/
+                RU::r12,
+                RU::r13,
+                RU::r14,
+                RU::r15,
+            ]
+        } else {
+            &[RU::rbx, RU::r12, RU::r13, RU::r14, RU::r15]
+        }
     } else {
         &[RU::rbx, RU::rsi, RU::rdi]
     }
@@ -215,7 +256,7 @@ pub fn prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::Ct
         CallConv::Fast | CallConv::Cold | CallConv::SystemV => {
             system_v_prologue_epilogue(func, isa)
         }
-        CallConv::Fastcall => unimplemented!("Windows calling conventions"),
+        CallConv::WindowsFastcall => fastcall_prologue_epilogue(func, isa),
         CallConv::Baldrdash => baldrdash_prologue_epilogue(func, isa),
         CallConv::Probestack => unimplemented!("probestack calling convention"),
     }
@@ -240,6 +281,83 @@ pub fn baldrdash_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> 
     Ok(())
 }
 
+/// Implementation of the fastcall-based Win64 calling convention described at [1]
+/// [1] https://msdn.microsoft.com/en-us/library/ms235286.aspx
+pub fn fastcall_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::CtonResult {
+    if !isa.flags().is_64bit() {
+        panic!("TODO: windows-fastcall: x86-32 not implemented yet");
+    }
+
+    // [1] "The primary exceptions are the stack pointer and malloc or alloca memory,
+    // which are aligned to 16 bytes in order to aid performance"
+    let stack_align = 16;
+
+    let word_size = if isa.flags().is_64bit() { 8 } else { 4 };
+    let reg_type = if isa.flags().is_64bit() {
+        ir::types::I64
+    } else {
+        ir::types::I32
+    };
+
+    let csrs = callee_saved_gprs_used(isa.flags(), func);
+
+    // [1] "Space is allocated on the call stack as a shadow store for callees to save"
+    // This shadow store contains the parameters which are passed through registers (ARG_GPRS)
+    // and is eventually used by the callee to save & restore the values of the arguments.
+    //
+    // [2] https://blogs.msdn.microsoft.com/oldnewthing/20110302-00/?p=11333
+    // "Although the x64 calling convention reserves spill space for parameters,
+    //  you don’t have to use them as such"
+    //
+    // The reserved stack area is composed of:
+    //   return address + frame pointer + all callee-saved registers + shadow space
+    //
+    // Pushing the return address is an implicit function of the `call`
+    // instruction. Each of the others we will then push explicitly. Then we
+    // will adjust the stack pointer to make room for the rest of the required
+    // space for this frame.
+    const SHADOW_STORE_SIZE: i32 = 32;
+    let csr_stack_size = ((csrs.iter(GPR).len() + 2) * word_size) as i32;
+
+    // TODO: eventually use the 32 bytes (shadow store) as spill slot. This currently doesn't work
+    //       since cretonne does not support spill slots before incoming args
+
+    func.create_stack_slot(ir::StackSlotData {
+        kind: ir::StackSlotKind::IncomingArg,
+        size: csr_stack_size as u32,
+        offset: Some(-(SHADOW_STORE_SIZE + csr_stack_size)),
+    });
+
+    let total_stack_size = layout_stack(&mut func.stack_slots, stack_align)? as i32;
+    let local_stack_size = i64::from(total_stack_size - csr_stack_size);
+
+    // Add CSRs to function signature
+    let fp_arg = ir::AbiParam::special_reg(
+        reg_type,
+        ir::ArgumentPurpose::FramePointer,
+        RU::rbp as RegUnit,
+    );
+    func.signature.params.push(fp_arg);
+    func.signature.returns.push(fp_arg);
+
+    for csr in csrs.iter(GPR) {
+        let csr_arg = ir::AbiParam::special_reg(reg_type, ir::ArgumentPurpose::CalleeSaved, csr);
+        func.signature.params.push(csr_arg);
+        func.signature.returns.push(csr_arg);
+    }
+
+    // Set up the cursor and insert the prologue
+    let entry_ebb = func.layout.entry_block().expect("missing entry block");
+    let mut pos = EncCursor::new(func, isa).at_first_insertion_point(entry_ebb);
+    insert_system_v_prologue(&mut pos, local_stack_size, reg_type, &csrs, isa);
+
+    // Reset the cursor and insert the epilogue
+    let mut pos = pos.at_position(CursorPosition::Nowhere);
+    insert_system_v_epilogues(&mut pos, local_stack_size, reg_type, &csrs);
+
+    Ok(())
+}
+
 /// Insert a System V-compatible prologue and epilogue.
 pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> result::CtonResult {
     // The original 32-bit x86 ELF ABI had a 4-byte aligned stack pointer, but
@@ -261,7 +379,7 @@ pub fn system_v_prologue_epilogue(func: &mut ir::Function, isa: &TargetIsa) -> r
     // instruction. Each of the others we will then push explicitly. Then we
     // will adjust the stack pointer to make room for the rest of the required
     // space for this frame.
-    let csr_stack_size = ((csrs.iter(GPR).len() + 2) * word_size as usize) as i32;
+    let csr_stack_size = ((csrs.iter(GPR).len() + 2) * word_size) as i32;
     func.create_stack_slot(ir::StackSlotData {
         kind: ir::StackSlotKind::IncomingArg,
         size: csr_stack_size as u32,

--- a/lib/native/src/lib.rs
+++ b/lib/native/src/lib.rs
@@ -37,7 +37,7 @@ pub fn builders() -> Result<(settings::Builder, isa::Builder), &'static str> {
     if cfg!(any(unix, target_os = "nebulet")) {
         flag_builder.set("call_conv", "system_v").unwrap();
     } else if cfg!(windows) {
-        flag_builder.set("call_conv", "fastcall").unwrap();
+        flag_builder.set("call_conv", "windows_fastcall").unwrap();
     } else {
         return Err("unrecognized environment");
     }

--- a/lib/simplejit/Cargo.toml
+++ b/lib/simplejit/Cargo.toml
@@ -16,6 +16,9 @@ region = "0.2.0"
 libc = { version = "0.2.40", default-features = false }
 errno = "0.2.3"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { version = "0.3", features = ["winbase", "memoryapi"] }
+
 [features]
 default = ["std"]
 std = ["libc/use_std", "cretonne-codegen/std", "cretonne-module/std", "cretonne-native/std"]

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -9,6 +9,8 @@ use cretonne_native;
 use std::ffi::CString;
 use std::ptr;
 use libc;
+#[cfg(windows)]
+use winapi;
 use memory::Memory;
 
 /// A builder for `SimpleJITBackend`.
@@ -344,6 +346,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
     fn finish(self) -> () {}
 }
 
+#[cfg(not(windows))]
 fn lookup_with_dlsym(name: &str) -> *const u8 {
     let c_str = CString::new(name).unwrap();
     let c_str_ptr = c_str.as_ptr();
@@ -352,6 +355,38 @@ fn lookup_with_dlsym(name: &str) -> *const u8 {
         panic!("can't resolve symbol {}", name);
     }
     sym as *const u8
+}
+
+#[cfg(windows)]
+fn lookup_with_dlsym(name: &str) -> *const u8 {
+    const MSVCRT_DLL: &[u8] = b"msvcrt.dll\0";
+
+    let c_str = CString::new(name).unwrap();
+    let c_str_ptr = c_str.as_ptr();
+
+    unsafe {
+        let handles = [
+            // try to find the searched symbol in the currently running executable
+            ptr::null_mut(),
+            // try to find the searched symbol in local c runtime
+            winapi::um::libloaderapi::GetModuleHandleA(MSVCRT_DLL.as_ptr() as *const i8),
+        ];
+
+        for handle in &handles {
+            let addr = winapi::um::libloaderapi::GetProcAddress(*handle, c_str_ptr);
+            if addr.is_null() {
+                continue;
+            }
+            return addr as *const u8;
+        }
+
+        let msg = if handles[1].is_null() {
+            "(msvcrt not loaded)"
+        } else {
+            ""
+        };
+        panic!("cannot resolve address of symbol {} {}", name, msg);
+    }
 }
 
 struct SimpleJITRelocSink {

--- a/lib/simplejit/src/lib.rs
+++ b/lib/simplejit/src/lib.rs
@@ -23,6 +23,9 @@ extern crate errno;
 extern crate region;
 extern crate libc;
 
+#[cfg(target_os = "windows")]
+extern crate winapi;
+
 mod backend;
 mod memory;
 


### PR DESCRIPTION
This adds support for the windows x64 fastcall-based calling convention 
(default calling convention on Win64)
described at https://msdn.microsoft.com/en-us/library/ms235286.aspx

The state in this commit (plus minor patches for simplejit on its repository) are enough,
to run those basic examples on windows.

## TODOS
- [x] Add more filetests
- [x] Test float arguments & return values (since they use XMM registers)
        Tested with patched simplejit and ceilf call locally
- [x] Test with MINGW based rust toolchain (MINGW build)
- [x] test generated functions being called from differently generated ones (e.g. C/WINAPI callback)
       to ensure prologue/epilogue is compatible not only in theory (very basic tests done)
- ~ensure argument registers, when required, are spilled into the "shadow store~
- [x] Check "spec" again for missed requirements
- [x] test simplejit with stack slots (> 5 arguments, tested with up to 45 int arguments at a recursion depth of 40)

References #305.