### PR TITLE
Fix minor comment typo.

### DIFF
--- a/lib/codegen/src/timing.rs
+++ b/lib/codegen/src/timing.rs
@@ -122,7 +122,7 @@ mod details {
     /// Accumulated timing information for a single pass.
     #[derive(Default)]
     struct PassTime {
-        /// Total time spent running this pas including children.
+        /// Total time spent running this pass including children.
         total: Duration,
 
         /// Time spent running in child passes.


### PR DESCRIPTION
Fixed a minor typo in the `PassTime` struct's comments found while familiarizing myself with the codebase to work on a different issue.