### PR TITLE
cretonne-faerie: add a translation mechanism for LibCalls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_install:
     - wget https://storage.googleapis.com/wasm-llvm/builds/linux/26619/wasm-toolchain_0.1.26619_amd64.deb
     - sudo dpkg -i wasm-toolchain_0.1.26619_amd64.deb
 install:
-    - pip3 install --user --upgrade mypy flake8
-    - mypy --version
+    - pip3 install --user --upgrade mypy==0.521 flake8
     - travis_wait ./check-rustfmt.sh --install
 script: ./test-all.sh
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
     - sudo dpkg -i wasm-toolchain_0.1.26619_amd64.deb
 install:
     - pip3 install --user --upgrade mypy flake8
+    - mypy --version
     - travis_wait ./check-rustfmt.sh --install
 script: ./test-all.sh
 cache:

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -42,6 +42,11 @@ impl FaerieBuilder {
     ///
     /// `collect_traps` setting determines whether trap information is collected in a
     /// `FaerieTrapManifest` available in the `FaerieProduct`.
+    ///
+    /// `libcall_names` vector provides a way to translate `cretonne_codegen`'s `ir::LibCall` enum
+    /// to symbols. LibCalls are inserted in the IR as part of the legalization for certain
+    /// floating point instructions, and for stack probes. If you don't know what to use for this
+    /// argument, use `FaerieBuilder::default_libcall_names()`.
     pub fn new(
         isa: Box<TargetIsa>,
         name: String,
@@ -82,7 +87,6 @@ impl FaerieBuilder {
             "round".to_owned(),
         ]
     }
-
 }
 
 
@@ -93,7 +97,10 @@ impl FaerieBuilder {
 #[test]
 fn check_libcall_names() {
     let names = FaerieBuilder::default_libcall_names();
-    assert_eq!(names[ir::LibCall::Probestack as usize], "__cretonne_probestack");
+    assert_eq!(
+        names[ir::LibCall::Probestack as usize],
+        "__cretonne_probestack"
+    );
     assert_eq!(names[ir::LibCall::CeilF32 as usize], "ceilf");
     assert_eq!(names[ir::LibCall::CeilF64 as usize], "ceil");
     assert_eq!(names[ir::LibCall::FloorF32 as usize], "floorf");

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -86,8 +86,8 @@ impl FaerieBuilder {
             ir::LibCall::FloorF64 => "floor".to_owned(),
             ir::LibCall::TruncF32 => "truncf".to_owned(),
             ir::LibCall::TruncF64 => "trunc".to_owned(),
-            ir::LibCall::NearestF32 => "nearbyint".to_owned(),
-            ir::LibCall::NearestF64 => "nearbyintf".to_owned(),
+            ir::LibCall::NearestF32 => "nearbyintf".to_owned(),
+            ir::LibCall::NearestF64 => "nearbyint".to_owned(),
         })
     }
 }

--- a/lib/faerie/src/backend.rs
+++ b/lib/faerie/src/backend.rs
@@ -48,16 +48,13 @@ impl FaerieBuilder {
     /// enum to symbols. LibCalls are inserted in the IR as part of the legalization for certain
     /// floating point instructions, and for stack probes. If you don't know what to use for this
     /// argument, use `FaerieBuilder::default_libcall_names()`.
-    pub fn new<F>(
+    pub fn new(
         isa: Box<TargetIsa>,
         name: String,
         format: container::Format,
         collect_traps: FaerieTrapCollection,
-        libcall_names: &'static F,
-    ) -> Result<Self, ModuleError>
-    where
-        F: Fn(ir::LibCall) -> String,
-    {
+        libcall_names: Box<Fn(ir::LibCall) -> String>,
+    ) -> Result<Self, ModuleError> {
         if !isa.flags().is_pic() {
             return Err(ModuleError::Backend(
                 "faerie requires TargetIsa be PIC".to_owned(),
@@ -70,7 +67,7 @@ impl FaerieBuilder {
             format,
             faerie_target,
             collect_traps,
-            libcall_names: Box::new(libcall_names),
+            libcall_names,
         })
     }
 


### PR DESCRIPTION
Exposes a new field `libcall_names: Vec<String>` in `FaerieBuilder`, and a new method `FaerieBuilder::default_libcall_names` to provide sensible default values for those libcalls.

The `FaerieTrapSink` looks up any libcall in the names provided, imports that function, and makes a link to it, instead of panicking on encountering a libcall.