### PR TITLE
Fixes for mypy 0.600

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
     - wget https://storage.googleapis.com/wasm-llvm/builds/linux/26619/wasm-toolchain_0.1.26619_amd64.deb
     - sudo dpkg -i wasm-toolchain_0.1.26619_amd64.deb
 install:
-    - pip3 install --user --upgrade mypy==0.521 flake8
+    - pip3 install --user --upgrade mypy flake8
+    - mypy --version
     - travis_wait ./check-rustfmt.sh --install
 script: ./test-all.sh
 cache:

--- a/lib/codegen/meta/isa/arm32/__init__.py
+++ b/lib/codegen/meta/isa/arm32/__init__.py
@@ -9,6 +9,7 @@ This target ISA generates code for ARMv7 and ARMv8 CPUs in 32-bit mode
 from __future__ import absolute_import
 from . import defs
 from . import settings, registers  # noqa
+from cdsl.isa import TargetISA  # noqa
 
 # Re-export the primary target ISA definition.
-ISA = defs.ISA.finish()
+ISA = defs.ISA.finish()  # type: TargetISA

--- a/lib/codegen/meta/isa/arm32/defs.py
+++ b/lib/codegen/meta/isa/arm32/defs.py
@@ -8,7 +8,7 @@ from cdsl.isa import TargetISA, CPUMode
 import base.instructions
 from base.legalize import narrow
 
-ISA = TargetISA('arm32', [base.instructions.GROUP])
+ISA = TargetISA('arm32', [base.instructions.GROUP])  # type: TargetISA
 
 # CPU modes for 32-bit ARM and Thumb2.
 A32 = CPUMode('A32', ISA)

--- a/lib/codegen/meta/isa/arm64/__init__.py
+++ b/lib/codegen/meta/isa/arm64/__init__.py
@@ -8,6 +8,7 @@ ARMv8 CPUs running the Aarch64 architecture.
 from __future__ import absolute_import
 from . import defs
 from . import settings, registers  # noqa
+from cdsl.isa import TargetISA  # noqa
 
 # Re-export the primary target ISA definition.
-ISA = defs.ISA.finish()
+ISA = defs.ISA.finish()  # type: TargetISA

--- a/lib/codegen/meta/isa/arm64/defs.py
+++ b/lib/codegen/meta/isa/arm64/defs.py
@@ -8,7 +8,7 @@ from cdsl.isa import TargetISA, CPUMode
 import base.instructions
 from base.legalize import narrow
 
-ISA = TargetISA('arm64', [base.instructions.GROUP])
+ISA = TargetISA('arm64', [base.instructions.GROUP])  # type: TargetISA
 A64 = CPUMode('A64', ISA)
 
 # TODO: Refine these

--- a/lib/codegen/meta/isa/riscv/__init__.py
+++ b/lib/codegen/meta/isa/riscv/__init__.py
@@ -27,6 +27,7 @@ RV32G / RV64G
 from __future__ import absolute_import
 from . import defs
 from . import encodings, settings, registers  # noqa
+from cdsl.isa import TargetISA  # noqa
 
 # Re-export the primary target ISA definition.
-ISA = defs.ISA.finish()
+ISA = defs.ISA.finish()  # type: TargetISA

--- a/lib/codegen/meta/isa/riscv/defs.py
+++ b/lib/codegen/meta/isa/riscv/defs.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from cdsl.isa import TargetISA, CPUMode
 import base.instructions
 
-ISA = TargetISA('riscv', [base.instructions.GROUP])
+ISA = TargetISA('riscv', [base.instructions.GROUP])  # type: TargetISA
 
 # CPU modes for 32-bit and 64-bit operation.
 RV32 = CPUMode('RV32', ISA)

--- a/lib/codegen/meta/isa/x86/__init__.py
+++ b/lib/codegen/meta/isa/x86/__init__.py
@@ -16,6 +16,7 @@ This target ISA generates code for x86 CPUs with two separate CPU modes:
 from __future__ import absolute_import
 from . import defs
 from . import encodings, settings, registers  # noqa
+from cdsl.isa import TargetISA  # noqa
 
 # Re-export the primary target ISA definition.
-ISA = defs.ISA.finish()
+ISA = defs.ISA.finish()  # type: TargetISA

--- a/lib/codegen/meta/isa/x86/defs.py
+++ b/lib/codegen/meta/isa/x86/defs.py
@@ -9,7 +9,7 @@ import base.instructions
 from . import instructions as x86
 from base.immediates import floatcc
 
-ISA = TargetISA('x86', [base.instructions.GROUP, x86.GROUP])
+ISA = TargetISA('x86', [base.instructions.GROUP, x86.GROUP])  # type: TargetISA
 
 # CPU modes for 32-bit and 64-bit operation.
 X86_64 = CPUMode('I64', ISA)

--- a/lib/codegen/meta/mypy.ini
+++ b/lib/codegen/meta/mypy.ini
@@ -2,3 +2,4 @@
 disallow_untyped_defs = True
 warn_unused_ignores = True
 warn_return_any = True
+strict_optional = False


### PR DESCRIPTION
The error message said `ISA` and pointed to the initialization of the `ISA` variable in __int__.py, but the trick was that the `ISA` variable in `defs.py` also needed an annotation.

This fixes #323.