### PR TITLE
x86 recipes: emit StackOverflow trap for all sp-relative loads and stores

### DIFF
--- a/filetests/isa/x86/binary32-float.cton
+++ b/filetests/isa/x86/binary32-float.cton
@@ -176,19 +176,19 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movss %xmm5, 1032(%esp)
-    [-,ss1]             v200 = spill v100                       ; bin: f3 0f 11 ac 24 00000408
+    [-,ss1]             v200 = spill v100                       ; bin: stk_ovf f3 0f 11 ac 24 00000408
     ; asm: movss %xmm2, 1032(%esp)
-    [-,ss1]             v201 = spill v101                       ; bin: f3 0f 11 94 24 00000408
+    [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f3 0f 11 94 24 00000408
 
     ; asm: movss 1032(%esp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: f3 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f3 0f 10 ac 24 00000408
     ; asm: movss 1032(%esp), %xmm2
-    [-,%xmm2]           v211 = fill v201                        ; bin: f3 0f 10 94 24 00000408
+    [-,%xmm2]           v211 = fill v201                        ; bin: stk_ovf f3 0f 10 94 24 00000408
 
     ; asm: movss %xmm5, 1032(%esp)
-    regspill v100, %xmm5 -> ss1                                 ; bin: f3 0f 11 ac 24 00000408
+    regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f3 0f 11 ac 24 00000408
     ; asm: movss 1032(%esp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: f3 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f3 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;
@@ -391,19 +391,19 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movsd %xmm5, 1032(%esp)
-    [-,ss1]             v200 = spill v100                       ; bin: f2 0f 11 ac 24 00000408
+    [-,ss1]             v200 = spill v100                       ; bin: stk_ovf f2 0f 11 ac 24 00000408
     ; asm: movsd %xmm2, 1032(%esp)
-    [-,ss1]             v201 = spill v101                       ; bin: f2 0f 11 94 24 00000408
+    [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f2 0f 11 94 24 00000408
 
     ; asm: movsd 1032(%esp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: f2 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f2 0f 10 ac 24 00000408
     ; asm: movsd 1032(%esp), %xmm2
-    [-,%xmm2]           v211 = fill v201                        ; bin: f2 0f 10 94 24 00000408
+    [-,%xmm2]           v211 = fill v201                        ; bin: stk_ovf f2 0f 10 94 24 00000408
 
     ; asm: movsd %xmm5, 1032(%esp)
-    regspill v100, %xmm5 -> ss1                                 ; bin: f2 0f 11 ac 24 00000408
+    regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f2 0f 11 ac 24 00000408
     ; asm: movsd 1032(%esp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: f2 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f2 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;

--- a/filetests/isa/x86/binary32.cton
+++ b/filetests/isa/x86/binary32.cton
@@ -352,7 +352,7 @@ ebb0:
     [-,%rsi]             v351 = bint.i32 v301   ; bin: 0f b6 f2
 
     ; asm: call foo
-    call fn0()                                  ; bin: e8 PCRel4(%foo-4) 00000000
+    call fn0()                                  ; bin: stk_ovf e8 PCRel4(%foo-4) 00000000
 
     ; asm: movl $0, %ecx
     [-,%rcx]            v400 = func_addr.i32 fn0        ; bin: b9 Abs4(%foo) 00000000
@@ -360,9 +360,9 @@ ebb0:
     [-,%rsi]            v401 = func_addr.i32 fn0        ; bin: be Abs4(%foo) 00000000
 
     ; asm: call *%ecx
-    call_indirect sig0, v400()                  ; bin: ff d1
+    call_indirect sig0, v400()                  ; bin: stk_ovf ff d1
     ; asm: call *%esi
-    call_indirect sig0, v401()                  ; bin: ff d6
+    call_indirect sig0, v401()                  ; bin: stk_ovf ff d6
 
     ; asm: movl $0, %ecx
     [-,%rcx]            v450 = globalsym_addr.i32 gv0    ; bin: b9 Abs4(%some_gv) 00000000
@@ -372,25 +372,25 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movl %ecx, 1032(%esp)
-    [-,ss1]             v500 = spill v1         ; bin: 89 8c 24 00000408
+    [-,ss1]             v500 = spill v1         ; bin: stk_ovf 89 8c 24 00000408
     ; asm: movl %esi, 1032(%esp)
-    [-,ss1]             v501 = spill v2         ; bin: 89 b4 24 00000408
+    [-,ss1]             v501 = spill v2         ; bin: stk_ovf 89 b4 24 00000408
 
     ; asm: movl 1032(%esp), %ecx
-    [-,%rcx]            v510 = fill v500        ; bin: 8b 8c 24 00000408
+    [-,%rcx]            v510 = fill v500        ; bin: stk_ovf 8b 8c 24 00000408
     ; asm: movl 1032(%esp), %esi
-    [-,%rsi]            v511 = fill v501        ; bin: 8b b4 24 00000408
+    [-,%rsi]            v511 = fill v501        ; bin: stk_ovf 8b b4 24 00000408
 
     ; asm: movl %ecx, 1032(%esp)
-    regspill v1, %rcx -> ss1                    ; bin: 89 8c 24 00000408
+    regspill v1, %rcx -> ss1                    ; bin: stk_ovf 89 8c 24 00000408
     ; asm: movl 1032(%esp), %ecx
-    regfill v1, ss1 -> %rcx                     ; bin: 8b 8c 24 00000408
+    regfill v1, ss1 -> %rcx                     ; bin: stk_ovf 8b 8c 24 00000408
 
     ; Push and Pop
     ; asm: pushl %ecx
-    x86_push v1                                 ; bin: 51
+    x86_push v1                                 ; bin: stk_ovf 51
     ; asm: popl %ecx
-    [-,%rcx]            v512 = x86_pop.i32      ; bin: 59
+    [-,%rcx]            v512 = x86_pop.i32      ; bin: stk_ovf 59
 
     ; Adjust Stack Pointer Up
     ; asm: addl $64, %esp

--- a/filetests/isa/x86/binary64-float.cton
+++ b/filetests/isa/x86/binary64-float.cton
@@ -190,19 +190,19 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movss %xmm5, 1032(%rsp)
-    [-,ss1]             v200 = spill v100                       ; bin: f3 0f 11 ac 24 00000408
+    [-,ss1]             v200 = spill v100                       ; bin: stk_ovf f3 0f 11 ac 24 00000408
     ; asm: movss %xmm10, 1032(%rsp)
-    [-,ss1]             v201 = spill v101                       ; bin: f3 44 0f 11 94 24 00000408
+    [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f3 44 0f 11 94 24 00000408
 
     ; asm: movss 1032(%rsp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: f3 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f3 0f 10 ac 24 00000408
     ; asm: movss 1032(%rsp), %xmm10
-    [-,%xmm10]          v211 = fill v201                        ; bin: f3 44 0f 10 94 24 00000408
+    [-,%xmm10]          v211 = fill v201                        ; bin: stk_ovf f3 44 0f 10 94 24 00000408
 
     ; asm: movss %xmm5, 1032(%rsp)
-    regspill v100, %xmm5 -> ss1                                 ; bin: f3 0f 11 ac 24 00000408
+    regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f3 0f 11 ac 24 00000408
     ; asm: movss 1032(%rsp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: f3 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f3 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;
@@ -425,19 +425,19 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movsd %xmm5, 1032(%rsp)
-    [-,ss1]             v200 = spill v100                       ; bin: f2 0f 11 ac 24 00000408
+    [-,ss1]             v200 = spill v100                       ; bin: stk_ovf f2 0f 11 ac 24 00000408
     ; asm: movsd %xmm10, 1032(%rsp)
-    [-,ss1]             v201 = spill v101                       ; bin: f2 44 0f 11 94 24 00000408
+    [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f2 44 0f 11 94 24 00000408
 
     ; asm: movsd 1032(%rsp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: f2 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f2 0f 10 ac 24 00000408
     ; asm: movsd 1032(%rsp), %xmm10
-    [-,%xmm10]          v211 = fill v201                        ; bin: f2 44 0f 10 94 24 00000408
+    [-,%xmm10]          v211 = fill v201                        ; bin: stk_ovf f2 44 0f 10 94 24 00000408
 
     ; asm: movsd %xmm5, 1032(%rsp)
-    regspill v100, %xmm5 -> ss1                                 ; bin: f2 0f 11 ac 24 00000408
+    regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f2 0f 11 ac 24 00000408
     ; asm: movsd 1032(%rsp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: f2 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f2 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;

--- a/filetests/isa/x86/binary64-pic.cton
+++ b/filetests/isa/x86/binary64-pic.cton
@@ -31,7 +31,7 @@ ebb0:
     ; Colocated functions.
 
     ; asm: call foo
-    call fn1()                                  ; bin: e8 PCRel4(%bar-4) 00000000
+    call fn1()                                  ; bin: stk_ovf e8 PCRel4(%bar-4) 00000000
 
     ; asm: lea 0x0(%rip), %rax
     [-,%rax]            v0 = func_addr.i64 fn1        ; bin: 48 8d 05 PCRel4(%bar-4) 00000000
@@ -41,16 +41,16 @@ ebb0:
     [-,%r10]            v2 = func_addr.i64 fn1        ; bin: 4c 8d 15 PCRel4(%bar-4) 00000000
 
     ; asm: call *%rax
-    call_indirect sig0, v0()                  ; bin: ff d0
+    call_indirect sig0, v0()                  ; bin: stk_ovf ff d0
     ; asm: call *%rsi
-    call_indirect sig0, v1()                  ; bin: ff d6
+    call_indirect sig0, v1()                  ; bin: stk_ovf ff d6
     ; asm: call *%r10
-    call_indirect sig0, v2()                  ; bin: 41 ff d2
+    call_indirect sig0, v2()                  ; bin: stk_ovf 41 ff d2
 
     ; Non-colocated functions.
 
     ; asm: call foo@PLT
-    call fn0()                                  ; bin: e8 PLTRel4(%foo-4) 00000000
+    call fn0()                                  ; bin: stk_ovf e8 PLTRel4(%foo-4) 00000000
 
     ; asm: mov 0x0(%rip), %rax
     [-,%rax]            v100 = func_addr.i64 fn0        ; bin: 48 8b 05 GOTPCRel4(%foo-4) 00000000
@@ -60,11 +60,11 @@ ebb0:
     [-,%r10]            v102 = func_addr.i64 fn0        ; bin: 4c 8b 15 GOTPCRel4(%foo-4) 00000000
 
     ; asm: call *%rax
-    call_indirect sig0, v100()                  ; bin: ff d0
+    call_indirect sig0, v100()                  ; bin: stk_ovf ff d0
     ; asm: call *%rsi
-    call_indirect sig0, v101()                  ; bin: ff d6
+    call_indirect sig0, v101()                  ; bin: stk_ovf ff d6
     ; asm: call *%r10
-    call_indirect sig0, v102()                  ; bin: 41 ff d2
+    call_indirect sig0, v102()                  ; bin: stk_ovf 41 ff d2
 
     ; asm: mov 0x0(%rip), %rcx
     [-,%rcx]            v3 = globalsym_addr.i64 gv0    ; bin: 48 8b 0d GOTPCRel4(%some_gv-4) 00000000

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -477,7 +477,7 @@ ebb0:
     ; Colocated functions.
 
     ; asm: call bar
-    call fn1()                                  ; bin: e8 PCRel4(%bar-4) 00000000
+    call fn1()                                  ; bin: stk_ovf e8 PCRel4(%bar-4) 00000000
 
     ; asm: lea 0x0(%rip), %rcx
     [-,%rcx]            v400 = func_addr.i64 fn1        ; bin: 48 8d 0d PCRel4(%bar-4) 00000000
@@ -487,11 +487,11 @@ ebb0:
     [-,%r10]            v402 = func_addr.i64 fn1        ; bin: 4c 8d 15 PCRel4(%bar-4) 00000000
 
     ; asm: call *%rcx
-    call_indirect sig0, v400()                  ; bin: ff d1
+    call_indirect sig0, v400()                  ; bin: stk_ovf ff d1
     ; asm: call *%rsi
-    call_indirect sig0, v401()                  ; bin: ff d6
+    call_indirect sig0, v401()                  ; bin: stk_ovf ff d6
     ; asm: call *%r10
-    call_indirect sig0, v402()                  ; bin: 41 ff d2
+    call_indirect sig0, v402()                  ; bin: stk_ovf 41 ff d2
 
     ; Non-colocated functions. Note that there is no non-colocated non-PIC call.
 
@@ -503,11 +503,11 @@ ebb0:
     [-,%r10]            v412 = func_addr.i64 fn0        ; bin: 49 ba Abs8(%foo) 0000000000000000
 
     ; asm: call *%rcx
-    call_indirect sig0, v410()                  ; bin: ff d1
+    call_indirect sig0, v410()                  ; bin: stk_ovf ff d1
     ; asm: call *%rsi
-    call_indirect sig0, v411()                  ; bin: ff d6
+    call_indirect sig0, v411()                  ; bin: stk_ovf ff d6
     ; asm: call *%r10
-    call_indirect sig0, v412()                  ; bin: 41 ff d2
+    call_indirect sig0, v412()                  ; bin: stk_ovf 41 ff d2
 
     ; asm: movabsq $-1, %rcx
     [-,%rcx]            v450 = globalsym_addr.i64 gv0    ; bin: 48 b9 Abs8(%some_gv) 0000000000000000
@@ -519,33 +519,33 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movq %rcx, 1032(%rsp)
-    [-,ss1]             v500 = spill v1         ; bin: 48 89 8c 24 00000408
+    [-,ss1]             v500 = spill v1         ; bin: stk_ovf 48 89 8c 24 00000408
     ; asm: movq %rsi, 1032(%rsp)
-    [-,ss1]             v501 = spill v2         ; bin: 48 89 b4 24 00000408
+    [-,ss1]             v501 = spill v2         ; bin: stk_ovf 48 89 b4 24 00000408
     ; asm: movq %r10, 1032(%rsp)
-    [-,ss1]             v502 = spill v3         ; bin: 4c 89 94 24 00000408
+    [-,ss1]             v502 = spill v3         ; bin: stk_ovf 4c 89 94 24 00000408
 
     ; asm: movq 1032(%rsp), %rcx
-    [-,%rcx]            v510 = fill v500        ; bin: 48 8b 8c 24 00000408
+    [-,%rcx]            v510 = fill v500        ; bin: stk_ovf 48 8b 8c 24 00000408
     ; asm: movq 1032(%rsp), %rsi
-    [-,%rsi]            v511 = fill v501        ; bin: 48 8b b4 24 00000408
+    [-,%rsi]            v511 = fill v501        ; bin: stk_ovf 48 8b b4 24 00000408
     ; asm: movq 1032(%rsp), %r10
-    [-,%r10]            v512 = fill v502        ; bin: 4c 8b 94 24 00000408
+    [-,%r10]            v512 = fill v502        ; bin: stk_ovf 4c 8b 94 24 00000408
 
     ; asm: movq %rcx, 1032(%rsp)
-    regspill v1, %rcx -> ss1                    ; bin: 48 89 8c 24 00000408
+    regspill v1, %rcx -> ss1                    ; bin: stk_ovf 48 89 8c 24 00000408
     ; asm: movq 1032(%rsp), %rcx
-    regfill v1, ss1 -> %rcx                     ; bin: 48 8b 8c 24 00000408
+    regfill v1, ss1 -> %rcx                     ; bin: stk_ovf 48 8b 8c 24 00000408
 
     ; Push and Pop
     ; asm: pushq %rcx
-    x86_push v1                                 ; bin: 51
+    x86_push v1                                 ; bin: stk_ovf 51
     ; asm: pushq %r10
-    x86_push v3                                 ; bin: 41 52
+    x86_push v3                                 ; bin: stk_ovf 41 52
     ; asm: popq %rcx
-    [-,%rcx]            v513 = x86_pop.i64      ; bin: 59
+    [-,%rcx]            v513 = x86_pop.i64      ; bin: stk_ovf 59
     ; asm: popq %r10
-    [-,%r10]            v514 = x86_pop.i64      ; bin: 41 5a
+    [-,%r10]            v514 = x86_pop.i64      ; bin: stk_ovf 41 5a
 
     ; Adjust Stack Pointer Up
     ; asm: addq $64, %rsp
@@ -732,9 +732,9 @@ ebb0:
     [-,%rcx]            v1 = iconst.i64 1
 
     ; asm: movq %rcx, 8(%rsp)
-    [-,ss1]             v10 = spill v1              ; bin: 48 89 8c 24 00000008
+    [-,ss1]             v10 = spill v1              ; bin: stk_ovf 48 89 8c 24 00000008
     ; asm: movq %rcx, (%rsp)
-    [-,ss2]             v11 = spill v1              ; bin: 48 89 8c 24 00000000
+    [-,ss2]             v11 = spill v1              ; bin: stk_ovf 48 89 8c 24 00000000
 
     return
 }
@@ -1094,23 +1094,23 @@ ebb0:
     ; Spill / Fill.
 
     ; asm: movl %ecx, 1032(%rsp)
-    [-,ss1]             v500 = spill v1         ; bin: 89 8c 24 00000408
+    [-,ss1]             v500 = spill v1         ; bin: stk_ovf 89 8c 24 00000408
     ; asm: movl %esi, 1032(%rsp)
-    [-,ss1]             v501 = spill v2         ; bin: 89 b4 24 00000408
+    [-,ss1]             v501 = spill v2         ; bin: stk_ovf 89 b4 24 00000408
     ; asm: movl %r10d, 1032(%rsp)
-    [-,ss1]             v502 = spill v3         ; bin: 44 89 94 24 00000408
+    [-,ss1]             v502 = spill v3         ; bin: stk_ovf 44 89 94 24 00000408
 
     ; asm: movl 1032(%rsp), %ecx
-    [-,%rcx]            v510 = fill v500        ; bin: 8b 8c 24 00000408
+    [-,%rcx]            v510 = fill v500        ; bin: stk_ovf 8b 8c 24 00000408
     ; asm: movl 1032(%rsp), %esi
-    [-,%rsi]            v511 = fill v501        ; bin: 8b b4 24 00000408
+    [-,%rsi]            v511 = fill v501        ; bin: stk_ovf 8b b4 24 00000408
     ; asm: movl 1032(%rsp), %r10d
-    [-,%r10]            v512 = fill v502        ; bin: 44 8b 94 24 00000408
+    [-,%r10]            v512 = fill v502        ; bin: stk_ovf 44 8b 94 24 00000408
 
     ; asm: movl %ecx, 1032(%rsp)
-    regspill v1, %rcx -> ss1                    ; bin: 89 8c 24 00000408
+    regspill v1, %rcx -> ss1                    ; bin: stk_ovf 89 8c 24 00000408
     ; asm: movl 1032(%rsp), %ecx
-    regfill v1, ss1 -> %rcx                     ; bin: 8b 8c 24 00000408
+    regfill v1, ss1 -> %rcx                     ; bin: stk_ovf 8b 8c 24 00000408
 
     ; asm: cmpl %esi, %ecx
     [-,%rflags]         v520 = ifcmp v1, v2      ; bin: 39 f1

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -546,12 +546,14 @@ pu_iq = TailRecipe(
 pushq = TailRecipe(
     'pushq', Unary, size=0, ins=GPR, outs=(),
     emit='''
+    sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
     PUT_OP(bits | (in_reg0 & 7), rex1(in_reg0), sink);
     ''')
 
 popq = TailRecipe(
     'popq', NullAry, size=0, ins=(), outs=GPR,
     emit='''
+    sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
     PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
     ''')
 

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -851,6 +851,7 @@ spillSib32 = TailRecipe(
         'spillSib32', Unary, size=6, ins=GPR, outs=StackGPR32,
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let base = stk_base(out_stk0.base);
         PUT_OP(bits, rex2(base, in_reg0), sink);
         modrm_sib_disp32(in_reg0, sink);
@@ -863,6 +864,7 @@ fspillSib32 = TailRecipe(
         'fspillSib32', Unary, size=6, ins=FPR, outs=StackFPR32,
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let base = stk_base(out_stk0.base);
         PUT_OP(bits, rex2(base, in_reg0), sink);
         modrm_sib_disp32(in_reg0, sink);
@@ -875,6 +877,7 @@ regspill32 = TailRecipe(
         'regspill32', RegSpill, size=6, ins=GPR, outs=(),
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let dst = StackRef::sp(dst, &func.stack_slots);
         let base = stk_base(dst.base);
         PUT_OP(bits, rex2(base, src), sink);
@@ -888,6 +891,7 @@ fregspill32 = TailRecipe(
         'fregspill32', RegSpill, size=6, ins=FPR, outs=(),
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let dst = StackRef::sp(dst, &func.stack_slots);
         let base = stk_base(dst.base);
         PUT_OP(bits, rex2(base, src), sink);
@@ -991,6 +995,7 @@ fillSib32 = TailRecipe(
         'fillSib32', Unary, size=6, ins=StackGPR32, outs=GPR,
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let base = stk_base(in_stk0.base);
         PUT_OP(bits, rex2(base, out_reg0), sink);
         modrm_sib_disp32(out_reg0, sink);
@@ -1003,6 +1008,7 @@ ffillSib32 = TailRecipe(
         'ffillSib32', Unary, size=6, ins=StackFPR32, outs=FPR,
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let base = stk_base(in_stk0.base);
         PUT_OP(bits, rex2(base, out_reg0), sink);
         modrm_sib_disp32(out_reg0, sink);
@@ -1015,6 +1021,7 @@ regfill32 = TailRecipe(
         'regfill32', RegFill, size=6, ins=StackGPR32, outs=(),
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let src = StackRef::sp(src, &func.stack_slots);
         let base = stk_base(src.base);
         PUT_OP(bits, rex2(base, dst), sink);
@@ -1028,6 +1035,7 @@ fregfill32 = TailRecipe(
         'fregfill32', RegFill, size=6, ins=StackFPR32, outs=(),
         clobbers_flags=False,
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let src = StackRef::sp(src, &func.stack_slots);
         let base = stk_base(src.base);
         PUT_OP(bits, rex2(base, dst), sink);
@@ -1042,6 +1050,7 @@ fregfill32 = TailRecipe(
 call_id = TailRecipe(
         'call_id', Call, size=4, ins=(), outs=(),
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         PUT_OP(bits, BASE_REX, sink);
         // The addend adjusts for the difference between the end of the
         // instruction and the beginning of the immediate field.
@@ -1054,6 +1063,7 @@ call_id = TailRecipe(
 call_plt_id = TailRecipe(
         'call_plt_id', Call, size=4, ins=(), outs=(),
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         PUT_OP(bits, BASE_REX, sink);
         sink.reloc_external(Reloc::X86PLTRel4,
                             &func.dfg.ext_funcs[func_ref].name,
@@ -1064,6 +1074,7 @@ call_plt_id = TailRecipe(
 call_r = TailRecipe(
         'call_r', CallIndirect, size=1, ins=GPR, outs=(),
         emit='''
+        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         PUT_OP(bits, rex1(in_reg0), sink);
         modrm_r_bits(in_reg0, bits, sink);
         ''')


### PR DESCRIPTION
This is the analog of the HeapOutOfBounds traps emitted on other loads and stores.

I'm not 100% sure that I caught every possible case.