### PR TITLE
Minor typo fix in `constant_hash` comment.

### DIFF
--- a/lib/codegen/meta/constant_hash.py
+++ b/lib/codegen/meta/constant_hash.py
@@ -2,7 +2,7 @@
 Generate constant hash tables.
 
 The `constant_hash` module can generate constant pre-populated hash tables. We
-don't attempt parfect hashing, but simply generate an open addressed
+don't attempt perfect hashing, but simply generate an open addressed
 quadratically probed hash table.
 """
 from __future__ import absolute_import


### PR DESCRIPTION
Found this while I was reading through the `lib/codegen` code, figured I would open up a PR to fix it :)