### PR TITLE
Improve coalescing performance by using a FxHashMap

### DIFF
--- a/lib/codegen/src/fx.rs
+++ b/lib/codegen/src/fx.rs
@@ -1,0 +1,111 @@
+// This file is taken from the Rust compiler: src/librustc_data_structures/fx.rs
+
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::collections::{HashMap, HashSet};
+use std::default::Default;
+use std::hash::{BuildHasherDefault, Hash, Hasher};
+use std::ops::BitXor;
+
+pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxHashSet<V> = HashSet<V, BuildHasherDefault<FxHasher>>;
+
+#[allow(non_snake_case)]
+pub fn FxHashMap<K: Hash + Eq, V>() -> FxHashMap<K, V> {
+    HashMap::default()
+}
+
+#[allow(non_snake_case)]
+pub fn FxHashSet<V: Hash + Eq>() -> FxHashSet<V> {
+    HashSet::default()
+}
+
+/// A speedy hash algorithm for use within rustc. The hashmap in liballoc
+/// by default uses SipHash which isn't quite as speedy as we want. In the
+/// compiler we're not really worried about DOS attempts, so we use a fast
+/// non-cryptographic hash.
+///
+/// This is the same as the algorithm used by Firefox -- which is a homespun
+/// one not based on any widely-known algorithm -- though modified to produce
+/// 64-bit hash values instead of 32-bit hash values. It consistently
+/// out-performs an FNV-based hash within rustc itself -- the collision rate is
+/// similar or slightly worse than FNV, but the speed of the hash function
+/// itself is much higher because it works on up to 8 bytes at a time.
+pub struct FxHasher {
+    hash: usize,
+}
+
+#[cfg(target_pointer_width = "32")]
+const K: usize = 0x9e3779b9;
+#[cfg(target_pointer_width = "64")]
+const K: usize = 0x517cc1b727220a95;
+
+impl Default for FxHasher {
+    #[inline]
+    fn default() -> FxHasher {
+        FxHasher { hash: 0 }
+    }
+}
+
+impl FxHasher {
+    #[inline]
+    fn add_to_hash(&mut self, i: usize) {
+        self.hash = self.hash.rotate_left(5).bitxor(i).wrapping_mul(K);
+    }
+}
+
+impl Hasher for FxHasher {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            let i = *byte;
+            self.add_to_hash(i as usize);
+        }
+    }
+
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.add_to_hash(i as usize);
+        self.add_to_hash((i >> 32) as usize);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        self.add_to_hash(i);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash as u64
+    }
+}

--- a/lib/codegen/src/lib.rs
+++ b/lib/codegen/src/lib.rs
@@ -95,6 +95,7 @@ mod constant_hash;
 mod context;
 mod dce;
 mod divconst_magic_numbers;
+mod fx;
 mod iterators;
 mod legalizer;
 mod licm;

--- a/lib/codegen/src/licm.rs
+++ b/lib/codegen/src/licm.rs
@@ -4,9 +4,9 @@ use cursor::{Cursor, FuncCursor};
 use dominator_tree::DominatorTree;
 use entity::{EntityList, ListPool};
 use flowgraph::ControlFlowGraph;
+use fx::FxHashSet;
 use ir::{DataFlowGraph, Ebb, Function, Inst, InstBuilder, Layout, Opcode, Type, Value};
 use loop_analysis::{Loop, LoopAnalysis};
-use std::collections::HashSet;
 use std::vec::Vec;
 use timing;
 
@@ -138,7 +138,7 @@ fn trivially_unsafe_for_licm(opcode: Opcode) -> bool {
 }
 
 /// Test whether the given instruction is loop-invariant.
-fn is_loop_invariant(inst: Inst, dfg: &DataFlowGraph, loop_values: &HashSet<Value>) -> bool {
+fn is_loop_invariant(inst: Inst, dfg: &DataFlowGraph, loop_values: &FxHashSet<Value>) -> bool {
     if trivially_unsafe_for_licm(dfg[inst].opcode()) {
         return false;
     }
@@ -162,7 +162,7 @@ fn remove_loop_invariant_instructions(
     cfg: &ControlFlowGraph,
     loop_analysis: &LoopAnalysis,
 ) -> Vec<Inst> {
-    let mut loop_values: HashSet<Value> = HashSet::new();
+    let mut loop_values: FxHashSet<Value> = FxHashSet();
     let mut invariant_insts: Vec<Inst> = Vec::new();
     let mut pos = FuncCursor::new(func);
     // We traverse the loop EBB in reverse post-order.
@@ -194,8 +194,8 @@ fn remove_loop_invariant_instructions(
 
 /// Return ebbs from a loop in post-order, starting from an entry point in the block.
 fn postorder_ebbs_loop(loop_analysis: &LoopAnalysis, cfg: &ControlFlowGraph, lp: Loop) -> Vec<Ebb> {
-    let mut grey = HashSet::new();
-    let mut black = HashSet::new();
+    let mut grey = FxHashSet();
+    let mut black = FxHashSet();
     let mut stack = vec![loop_analysis.loop_header(lp)];
     let mut postorder = Vec::new();
 

--- a/lib/codegen/src/regalloc/live_value_tracker.rs
+++ b/lib/codegen/src/regalloc/live_value_tracker.rs
@@ -6,12 +6,12 @@
 
 use dominator_tree::DominatorTree;
 use entity::{EntityList, ListPool};
+use fx::FxHashMap;
 use ir::{DataFlowGraph, Ebb, ExpandedProgramPoint, Inst, Layout, Value};
 use partition_slice::partition_slice;
 use regalloc::affinity::Affinity;
 use regalloc::liveness::Liveness;
 use regalloc::liverange::LiveRange;
-use std::collections::HashMap;
 use std::vec::Vec;
 
 type ValueList = EntityList<Value>;
@@ -25,7 +25,7 @@ pub struct LiveValueTracker {
     /// dominator of an EBB.
     ///
     /// This is the set of values that are live *before* the branch.
-    idom_sets: HashMap<Inst, ValueList>,
+    idom_sets: FxHashMap<Inst, ValueList>,
 
     /// Memory pool for the live sets.
     idom_pool: ListPool<Value>,
@@ -128,7 +128,7 @@ impl LiveValueTracker {
     pub fn new() -> Self {
         Self {
             live: LiveValueVec::new(),
-            idom_sets: HashMap::new(),
+            idom_sets: FxHashMap(),
             idom_pool: ListPool::new(),
         }
     }

--- a/lib/codegen/src/scoped_hash_map.rs
+++ b/lib/codegen/src/scoped_hash_map.rs
@@ -4,7 +4,8 @@
 //! container that has a concept of scopes that can be entered and exited, such that
 //! values inserted while inside a scope aren't visible outside the scope.
 
-use std::collections::{hash_map, HashMap};
+use fx::FxHashMap;
+use std::collections::hash_map;
 use std::hash::Hash;
 use std::mem;
 
@@ -58,7 +59,7 @@ pub enum Entry<'a, K: 'a, V: 'a> {
 /// Shadowing, where one scope has entries with the same keys as a containing scope,
 /// is not supported in this implementation.
 pub struct ScopedHashMap<K, V> {
-    map: HashMap<K, Val<K, V>>,
+    map: FxHashMap<K, Val<K, V>>,
     last_insert: Option<K>,
     current_depth: usize,
 }
@@ -70,7 +71,7 @@ where
     /// Creates an empty `ScopedHashMap`.
     pub fn new() -> Self {
         Self {
-            map: HashMap::new(),
+            map: FxHashMap(),
             last_insert: None,
             current_depth: 0,
         }


### PR DESCRIPTION
This improves the performance of `VirtualCopies::filter` by using a `FxHashMap` instead of a binary search.

I also changed all the `HashMap` in the `codegen` crate to `FxHashMap` for consistency, but there is no noticeable performance improvement since 80% of the time is spent in the register allocator.

## Performance results

Result from compiling `sqlite.wasm` show a 16.7% reduction in coalescing time, which translates to a 9.6% reduction in total compilation time.

Before:
```
$ perf stat target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa x86 ../wasm-collection/misc-valid/sqlite.wasm
======== ========  ==================================
   Total     Self  Pass
-------- --------  ----------------------------------
   0.319    0.001  Translate WASM module
   0.318    0.318  Translate WASM function
   2.961    0.037  Compilation passes
   0.009    0.009  Control flow graph
   0.014    0.014  Dominator tree
   0.034    0.032  Post-legalization rewriting
   0.017    0.017  Pre-legalization rewriting
   0.018    0.018  Dead code elimination
   0.108    0.104  Legalization
   0.000    0.000  Remove unreachable blocks
   2.710    0.001  Register allocation
   0.276    0.276  RA liveness analysis
   1.722    1.708  RA coalescing CSSA
   0.241    0.241  RA spilling
   0.207    0.207  RA reloading
   0.264    0.264  RA coloring
   0.013    0.013  Prologue/epilogue insertion
   0.020    0.020  Layout full renumbering
======== ========  ==================================

 Performance counter stats for 'target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa x86 ../wasm-collection/misc-valid/sqlite.wasm':

       3331.796606      task-clock (msec)         #    1.000 CPUs utilized          
                22      context-switches          #    0.007 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
            60,273      page-faults               #    0.018 M/sec                  
    10,049,185,059      cycles                    #    3.016 GHz                    
    22,985,804,643      instructions              #    2.29  insn per cycle         
     3,812,377,156      branches                  # 1144.241 M/sec                  
        54,570,693      branch-misses             #    1.43% of all branches        

       3.332527015 seconds time elapsed
```

After:
```
$ perf stat target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa x86 ../wasm-collection/misc-valid/sqlite.wasm
======== ========  ==================================
   Total     Self  Pass
-------- --------  ----------------------------------
   0.312    0.001  Translate WASM module
   0.311    0.311  Translate WASM function
   2.699    0.037  Compilation passes
   0.009    0.009  Control flow graph
   0.015    0.015  Dominator tree
   0.034    0.032  Post-legalization rewriting
   0.017    0.017  Pre-legalization rewriting
   0.017    0.017  Dead code elimination
   0.102    0.098  Legalization
   0.000    0.000  Remove unreachable blocks
   2.456    0.001  Register allocation
   0.292    0.292  RA liveness analysis
   1.475    1.459  RA coalescing CSSA
   0.233    0.233  RA spilling
   0.196    0.196  RA reloading
   0.259    0.259  RA coloring
   0.012    0.012  Prologue/epilogue insertion
   0.022    0.022  Layout full renumbering
======== ========  ==================================

 Performance counter stats for 'target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa x86 ../wasm-collection/misc-valid/sqlite.wasm':

       3062.545874      task-clock (msec)         #    1.000 CPUs utilized          
                 7      context-switches          #    0.002 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
            58,830      page-faults               #    0.019 M/sec                  
     9,542,870,453      cycles                    #    3.116 GHz                    
    21,550,752,471      instructions              #    2.26  insn per cycle         
     3,458,311,590      branches                  # 1129.228 M/sec                  
        48,707,280      branch-misses             #    1.41% of all branches        

       3.063093766 seconds time elapsed
```