### PR TITLE
Optimize partition_slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,11 @@ term = "0.5.1"
 capstone = "0.3.1"
 
 [workspace]
+
+# We want debug symbols on release binaries by default since it allows profiling
+# tools to give more accurate information. We can always strip them out later if
+# necessary.
+[profile.release]
+debug = true
+[profile.bench]
+debug = true


### PR DESCRIPTION
This function is called by `LiveValueTracker` which is used by many of the register allocation passes.

## Performance results

Result from compiling `tanks.wasm` show a 8% reduction in register allocation time, which translates to a 5% reduction in total compilation time.

Before:

```
$ perf stat target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa "x86 haswell" ../wasm-collection/misc-valid/tanks.wasm
======== ========  ==================================
   Total     Self  Pass
-------- --------  ----------------------------------
   1.476    0.047  Translate WASM module
   1.429    1.429  Translate WASM function
   7.500    0.237  Compilation passes
   0.069    0.069  Control flow graph
   0.101    0.101  Dominator tree
   0.219    0.219  Post-legalization rewriting
   0.056    0.056  Pre-legalization rewriting
   0.128    0.128  Dead code elimination
   0.793    0.792  Legalization
   0.003    0.003  Remove unreachable blocks
   5.746    0.014  Register allocation
   0.947    0.947  RA liveness analysis
   0.735    0.733  RA coalescing CSSA
   1.193    1.193  RA spilling
   1.139    1.139  RA reloading
   1.716    1.716  RA coloring
   0.148    0.148  Prologue/epilogue insertion
   0.005    0.005  Layout full renumbering
======== ========  ==================================

 Performance counter stats for 'target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa x86 haswell ../wasm-collection/misc-valid/tanks.wasm':

       9243.626105      task-clock (msec)         #    1.000 CPUs utilized          
               105      context-switches          #    0.011 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
           135,081      page-faults               #    0.015 M/sec                  
    29,730,493,637      cycles                    #    3.216 GHz                    
    67,649,986,845      instructions              #    2.28  insn per cycle         
    10,770,412,175      branches                  # 1165.172 M/sec                  
       194,551,707      branch-misses             #    1.81% of all branches        

       9.245220864 seconds time elapsed
```

After:

```
$ perf stat target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa "x86 haswell" ../wasm-collection/misc-valid/tanks.wasm
======== ========  ==================================
   Total     Self  Pass
-------- --------  ----------------------------------
   1.481    0.051  Translate WASM module
   1.430    1.430  Translate WASM function
   7.036    0.234  Compilation passes
   0.070    0.070  Control flow graph
   0.098    0.098  Dominator tree
   0.218    0.218  Post-legalization rewriting
   0.056    0.056  Pre-legalization rewriting
   0.128    0.128  Dead code elimination
   0.782    0.781  Legalization
   0.003    0.003  Remove unreachable blocks
   5.298    0.013  Register allocation
   0.907    0.907  RA liveness analysis
   0.725    0.722  RA coalescing CSSA
   1.080    1.080  RA spilling
   1.031    1.031  RA reloading
   1.542    1.542  RA coloring
   0.149    0.149  Prologue/epilogue insertion
   0.005    0.005  Layout full renumbering
======== ========  ==================================

 Performance counter stats for 'target/release/cton-util wasm -T --set enable_verifier=0 --set is_64bit=1 --isa x86 haswell ../wasm-collection/misc-valid/tanks.wasm':

       8807.353946      task-clock (msec)         #    1.000 CPUs utilized          
                19      context-switches          #    0.002 K/sec                  
                 0      cpu-migrations            #    0.000 K/sec                  
           135,098      page-faults               #    0.015 M/sec                  
    28,499,629,425      cycles                    #    3.236 GHz                    
    64,111,783,709      instructions              #    2.25  insn per cycle         
    10,880,589,936      branches                  # 1235.398 M/sec                  
       193,109,901      branch-misses             #    1.77% of all branches        

       8.808385471 seconds time elapsed
```