### PR TITLE
Allow wasm embedders to reject wasm modules with unsupported features.

### DIFF
--- a/lib/codegen/src/result.rs
+++ b/lib/codegen/src/result.rs
@@ -7,13 +7,6 @@ use verifier;
 /// When Cretonne fails to compile a function, it will return one of these error codes.
 #[derive(Fail, Debug, PartialEq, Eq)]
 pub enum CtonError {
-    /// The input is invalid.
-    ///
-    /// This error code is used by a WebAssembly translator when it encounters invalid WebAssembly
-    /// code. This should never happen for validated WebAssembly code.
-    #[fail(display = "Invalid input code")]
-    InvalidInput,
-
     /// An IR verifier error.
     ///
     /// This always represents a bug, either in the code that generated IR for Cretonne, or a bug

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -13,6 +13,8 @@ wasmparser = { version = "0.16.1", default-features = false }
 cretonne-codegen = { path = "../codegen", version = "0.8.0", default-features = false }
 cretonne-frontend = { path = "../frontend", version = "0.8.0", default-features = false }
 hashmap_core = { version = "0.1.4", optional = true }
+failure = { version = "0.1.1", default-features = false, features = ["derive"] }
+failure_derive = { version = "0.1.1", default-features = false }
 
 [dev-dependencies]
 tempdir = "0.3.5"

--- a/lib/wasm/src/environ/mod.rs
+++ b/lib/wasm/src/environ/mod.rs
@@ -4,4 +4,4 @@ mod dummy;
 mod spec;
 
 pub use environ::dummy::DummyEnvironment;
-pub use environ::spec::{FuncEnvironment, GlobalValue, ModuleEnvironment};
+pub use environ::spec::{FuncEnvironment, GlobalValue, ModuleEnvironment, WasmError, WasmResult};

--- a/lib/wasm/src/lib.rs
+++ b/lib/wasm/src/lib.rs
@@ -42,6 +42,10 @@ extern crate cretonne_codegen;
 extern crate cretonne_frontend;
 extern crate wasmparser;
 
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
 mod code_translator;
 mod environ;
 mod func_translator;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -105,7 +105,9 @@ fn handle_module(
     }
 
     let mut dummy_environ = DummyEnvironment::with_flags(fisa.flags.clone());
-    translate_module(&data, &mut dummy_environ)?;
+    translate_module(&data, &mut dummy_environ).map_err(
+        |e| e.to_string(),
+    )?;
 
     terminal.fg(term::color::GREEN).unwrap();
     vprintln!(flag_verbose, "ok");


### PR DESCRIPTION
Define `WasmError` (and an accompanying `WasmResult`) to represent
errors translating WebAssembly functions. Make `translate_call` and
related functions return `WasmResult`s so that embedders have the
flexibility to reject features they don't support.

Move `InvalidInput` out of `CtonError` and into `WasmError`, where it's
now named `InvalidWebAssembly`, as it's a WebAssembly-specific error
condition. Also extend it to preserve the original error message and
bytecode offset.

@lachlansneff Does this look like it would work for your use case?