### PR TITLE
Use "nightly" feature of raw-cpuid when possible.

### DIFF
--- a/lib/native/Cargo.toml
+++ b/lib/native/Cargo.toml
@@ -16,7 +16,10 @@ raw-cpuid = "3.1.0"
 [features]
 default = ["std"]
 std = ["cretonne-codegen/std"]
-core = ["cretonne-codegen/core"]
+# when compiling with the "core" feature, nightly must be enabled
+# enabling the "nightly" feature for raw-cpuid allows avoiding
+# linking in a c-library.
+core = ["cretonne-codegen/core", "raw-cpuid/nightly"]
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION
The raw-cpuid library links in a c-library to call the `cpuid` instruction unless the nightly feature is enabled. When the `core` feature is enabled, enable the "nightly" feature for `raw-cpuid` to avoid that.