### PR TITLE
Pop and fill don't trigger StackOverflow.

### DIFF
--- a/filetests/isa/x86/binary32-float.cton
+++ b/filetests/isa/x86/binary32-float.cton
@@ -181,14 +181,14 @@ ebb0:
     [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f3 0f 11 94 24 00000408
 
     ; asm: movss 1032(%esp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f3 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: f3 0f 10 ac 24 00000408
     ; asm: movss 1032(%esp), %xmm2
-    [-,%xmm2]           v211 = fill v201                        ; bin: stk_ovf f3 0f 10 94 24 00000408
+    [-,%xmm2]           v211 = fill v201                        ; bin: f3 0f 10 94 24 00000408
 
     ; asm: movss %xmm5, 1032(%esp)
     regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f3 0f 11 ac 24 00000408
     ; asm: movss 1032(%esp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f3 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: f3 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;
@@ -422,14 +422,14 @@ ebb0:
     [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f2 0f 11 94 24 00000408
 
     ; asm: movsd 1032(%esp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f2 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: f2 0f 10 ac 24 00000408
     ; asm: movsd 1032(%esp), %xmm2
-    [-,%xmm2]           v211 = fill v201                        ; bin: stk_ovf f2 0f 10 94 24 00000408
+    [-,%xmm2]           v211 = fill v201                        ; bin: f2 0f 10 94 24 00000408
 
     ; asm: movsd %xmm5, 1032(%esp)
     regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f2 0f 11 ac 24 00000408
     ; asm: movsd 1032(%esp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f2 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: f2 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;

--- a/filetests/isa/x86/binary32.cton
+++ b/filetests/isa/x86/binary32.cton
@@ -377,20 +377,20 @@ ebb0:
     [-,ss1]             v501 = spill v2         ; bin: stk_ovf 89 b4 24 00000408
 
     ; asm: movl 1032(%esp), %ecx
-    [-,%rcx]            v510 = fill v500        ; bin: stk_ovf 8b 8c 24 00000408
+    [-,%rcx]            v510 = fill v500        ; bin: 8b 8c 24 00000408
     ; asm: movl 1032(%esp), %esi
-    [-,%rsi]            v511 = fill v501        ; bin: stk_ovf 8b b4 24 00000408
+    [-,%rsi]            v511 = fill v501        ; bin: 8b b4 24 00000408
 
     ; asm: movl %ecx, 1032(%esp)
     regspill v1, %rcx -> ss1                    ; bin: stk_ovf 89 8c 24 00000408
     ; asm: movl 1032(%esp), %ecx
-    regfill v1, ss1 -> %rcx                     ; bin: stk_ovf 8b 8c 24 00000408
+    regfill v1, ss1 -> %rcx                     ; bin: 8b 8c 24 00000408
 
     ; Push and Pop
     ; asm: pushl %ecx
     x86_push v1                                 ; bin: stk_ovf 51
     ; asm: popl %ecx
-    [-,%rcx]            v512 = x86_pop.i32      ; bin: stk_ovf 59
+    [-,%rcx]            v512 = x86_pop.i32      ; bin: 59
 
     ; Adjust Stack Pointer Up
     ; asm: addl $64, %esp

--- a/filetests/isa/x86/binary64-float.cton
+++ b/filetests/isa/x86/binary64-float.cton
@@ -194,14 +194,14 @@ ebb0:
     [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f3 44 0f 11 94 24 00000408
 
     ; asm: movss 1032(%rsp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f3 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: f3 0f 10 ac 24 00000408
     ; asm: movss 1032(%rsp), %xmm10
-    [-,%xmm10]          v211 = fill v201                        ; bin: stk_ovf f3 44 0f 10 94 24 00000408
+    [-,%xmm10]          v211 = fill v201                        ; bin: f3 44 0f 10 94 24 00000408
 
     ; asm: movss %xmm5, 1032(%rsp)
     regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f3 0f 11 ac 24 00000408
     ; asm: movss 1032(%rsp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f3 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: f3 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;
@@ -457,14 +457,14 @@ ebb0:
     [-,ss1]             v201 = spill v101                       ; bin: stk_ovf f2 44 0f 11 94 24 00000408
 
     ; asm: movsd 1032(%rsp), %xmm5
-    [-,%xmm5]           v210 = fill v200                        ; bin: stk_ovf f2 0f 10 ac 24 00000408
+    [-,%xmm5]           v210 = fill v200                        ; bin: f2 0f 10 ac 24 00000408
     ; asm: movsd 1032(%rsp), %xmm10
-    [-,%xmm10]          v211 = fill v201                        ; bin: stk_ovf f2 44 0f 10 94 24 00000408
+    [-,%xmm10]          v211 = fill v201                        ; bin: f2 44 0f 10 94 24 00000408
 
     ; asm: movsd %xmm5, 1032(%rsp)
     regspill v100, %xmm5 -> ss1                                 ; bin: stk_ovf f2 0f 11 ac 24 00000408
     ; asm: movsd 1032(%rsp), %xmm5
-    regfill v100, ss1 -> %xmm5                                  ; bin: stk_ovf f2 0f 10 ac 24 00000408
+    regfill v100, ss1 -> %xmm5                                  ; bin: f2 0f 10 ac 24 00000408
 
     ; Comparisons.
     ;

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -534,16 +534,16 @@ ebb0:
     [-,ss1]             v502 = spill v3         ; bin: stk_ovf 4c 89 94 24 00000408
 
     ; asm: movq 1032(%rsp), %rcx
-    [-,%rcx]            v510 = fill v500        ; bin: stk_ovf 48 8b 8c 24 00000408
+    [-,%rcx]            v510 = fill v500        ; bin: 48 8b 8c 24 00000408
     ; asm: movq 1032(%rsp), %rsi
-    [-,%rsi]            v511 = fill v501        ; bin: stk_ovf 48 8b b4 24 00000408
+    [-,%rsi]            v511 = fill v501        ; bin: 48 8b b4 24 00000408
     ; asm: movq 1032(%rsp), %r10
-    [-,%r10]            v512 = fill v502        ; bin: stk_ovf 4c 8b 94 24 00000408
+    [-,%r10]            v512 = fill v502        ; bin: 4c 8b 94 24 00000408
 
     ; asm: movq %rcx, 1032(%rsp)
     regspill v1, %rcx -> ss1                    ; bin: stk_ovf 48 89 8c 24 00000408
     ; asm: movq 1032(%rsp), %rcx
-    regfill v1, ss1 -> %rcx                     ; bin: stk_ovf 48 8b 8c 24 00000408
+    regfill v1, ss1 -> %rcx                     ; bin: 48 8b 8c 24 00000408
 
     ; Push and Pop
     ; asm: pushq %rcx
@@ -551,9 +551,9 @@ ebb0:
     ; asm: pushq %r10
     x86_push v3                                 ; bin: stk_ovf 41 52
     ; asm: popq %rcx
-    [-,%rcx]            v513 = x86_pop.i64      ; bin: stk_ovf 59
+    [-,%rcx]            v513 = x86_pop.i64      ; bin: 59
     ; asm: popq %r10
-    [-,%r10]            v514 = x86_pop.i64      ; bin: stk_ovf 41 5a
+    [-,%r10]            v514 = x86_pop.i64      ; bin: 41 5a
 
     ; Adjust Stack Pointer Up
     ; asm: addq $64, %rsp
@@ -1192,16 +1192,16 @@ ebb0:
     [-,ss1]             v502 = spill v3         ; bin: stk_ovf 44 89 94 24 00000408
 
     ; asm: movl 1032(%rsp), %ecx
-    [-,%rcx]            v510 = fill v500        ; bin: stk_ovf 8b 8c 24 00000408
+    [-,%rcx]            v510 = fill v500        ; bin: 8b 8c 24 00000408
     ; asm: movl 1032(%rsp), %esi
-    [-,%rsi]            v511 = fill v501        ; bin: stk_ovf 8b b4 24 00000408
+    [-,%rsi]            v511 = fill v501        ; bin: 8b b4 24 00000408
     ; asm: movl 1032(%rsp), %r10d
-    [-,%r10]            v512 = fill v502        ; bin: stk_ovf 44 8b 94 24 00000408
+    [-,%r10]            v512 = fill v502        ; bin: 44 8b 94 24 00000408
 
     ; asm: movl %ecx, 1032(%rsp)
     regspill v1, %rcx -> ss1                    ; bin: stk_ovf 89 8c 24 00000408
     ; asm: movl 1032(%rsp), %ecx
-    regfill v1, ss1 -> %rcx                     ; bin: stk_ovf 8b 8c 24 00000408
+    regfill v1, ss1 -> %rcx                     ; bin: 8b 8c 24 00000408
 
     ; asm: cmpl %esi, %ecx
     [-,%rflags]         v520 = ifcmp v1, v2      ; bin: 39 f1

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -583,7 +583,6 @@ pushq = TailRecipe(
 popq = TailRecipe(
     'popq', NullAry, size=0, ins=(), outs=GPR,
     emit='''
-    sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
     PUT_OP(bits | (out_reg0 & 7), rex1(out_reg0), sink);
     ''')
 
@@ -1298,7 +1297,6 @@ fillSib32 = TailRecipe(
         'fillSib32', Unary, size=6, ins=StackGPR32, outs=GPR,
         clobbers_flags=False,
         emit='''
-        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let base = stk_base(in_stk0.base);
         PUT_OP(bits, rex2(base, out_reg0), sink);
         modrm_sib_disp32(out_reg0, sink);
@@ -1311,7 +1309,6 @@ ffillSib32 = TailRecipe(
         'ffillSib32', Unary, size=6, ins=StackFPR32, outs=FPR,
         clobbers_flags=False,
         emit='''
-        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let base = stk_base(in_stk0.base);
         PUT_OP(bits, rex2(base, out_reg0), sink);
         modrm_sib_disp32(out_reg0, sink);
@@ -1324,7 +1321,6 @@ regfill32 = TailRecipe(
         'regfill32', RegFill, size=6, ins=StackGPR32, outs=(),
         clobbers_flags=False,
         emit='''
-        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let src = StackRef::sp(src, &func.stack_slots);
         let base = stk_base(src.base);
         PUT_OP(bits, rex2(base, dst), sink);
@@ -1338,7 +1334,6 @@ fregfill32 = TailRecipe(
         'fregfill32', RegFill, size=6, ins=StackFPR32, outs=(),
         clobbers_flags=False,
         emit='''
-        sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         let src = StackRef::sp(src, &func.stack_slots);
         let base = stk_base(src.base);
         PUT_OP(bits, rex2(base, dst), sink);


### PR DESCRIPTION
In theory, pop and fill instructions should only be reading stack memory that has already been successfully written to, so they themselves should never be able to trigger `StackOverflow` traps. This reduces the amount of bookkeeping needed.
