### PR TITLE
Implement stack_addr, stack_load, stack_store for x86-64.

### DIFF
--- a/filetests/isa/x86/stack-addr64.cton
+++ b/filetests/isa/x86/stack-addr64.cton
@@ -1,0 +1,45 @@
+; binary emission of stack address instructions on x86-64.
+test binemit
+set opt_level=fastest
+target x86_64 haswell
+
+; The binary encodings can be verified with the command:
+;
+;   sed -ne 's/^ *; asm: *//p' filetests/isa/x86/stack-addr64.cton | llvm-mc -show-encoding -triple=x86_64
+;
+
+function %stack_addr() {
+           ss0 = incoming_arg 8, offset 0
+           ss1 = incoming_arg 1024, offset -1024
+           ss2 = incoming_arg 1024, offset -2048
+           ss3 = incoming_arg 8, offset -2056
+           ss4 = explicit_slot 8, offset 0
+           ss5 = explicit_slot 8, offset 1024
+
+ebb0:
+[-,%rcx]   v0 = stack_addr.i64 ss0                      ; bin: 48 8d 8c 24 00000808
+[-,%rcx]   v1 = stack_addr.i64 ss1                      ; bin: 48 8d 8c 24 00000408
+[-,%rcx]   v2 = stack_addr.i64 ss2                      ; bin: 48 8d 8c 24 00000008
+[-,%rcx]   v3 = stack_addr.i64 ss3                      ; bin: 48 8d 8c 24 00000000
+[-,%rcx]   v4 = stack_addr.i64 ss4                      ; bin: 48 8d 8c 24 00000808
+[-,%rcx]   v5 = stack_addr.i64 ss5                      ; bin: 48 8d 8c 24 00000c08
+
+[-,%rcx]   v20 = stack_addr.i64 ss4+1                   ; bin: 48 8d 8c 24 00000809
+[-,%rcx]   v21 = stack_addr.i64 ss4+2                   ; bin: 48 8d 8c 24 0000080a
+[-,%rcx]   v22 = stack_addr.i64 ss4+2048                ; bin: 48 8d 8c 24 00001008
+[-,%rcx]   v23 = stack_addr.i64 ss4-4096                ; bin: 48 8d 8c 24 fffff808
+
+[-,%r8]    v50 = stack_addr.i64 ss0                     ; bin: 4c 8d 84 24 00000808
+[-,%r8]    v51 = stack_addr.i64 ss1                     ; bin: 4c 8d 84 24 00000408
+[-,%r8]    v52 = stack_addr.i64 ss2                     ; bin: 4c 8d 84 24 00000008
+[-,%r8]    v53 = stack_addr.i64 ss3                     ; bin: 4c 8d 84 24 00000000
+[-,%r8]    v54 = stack_addr.i64 ss4                     ; bin: 4c 8d 84 24 00000808
+[-,%r8]    v55 = stack_addr.i64 ss5                     ; bin: 4c 8d 84 24 00000c08
+
+[-,%r8]    v70 = stack_addr.i64 ss4+1                   ; bin: 4c 8d 84 24 00000809
+[-,%r8]    v71 = stack_addr.i64 ss4+2                   ; bin: 4c 8d 84 24 0000080a
+[-,%r8]    v72 = stack_addr.i64 ss4+2048                ; bin: 4c 8d 84 24 00001008
+[-,%r8]    v73 = stack_addr.i64 ss4-4096                ; bin: 4c 8d 84 24 fffff808
+
+           return
+}

--- a/filetests/isa/x86/stack-load-store64.cton
+++ b/filetests/isa/x86/stack-load-store64.cton
@@ -1,0 +1,21 @@
+; legalization of stack load and store instructions on x86-64.
+test legalizer
+set opt_level=fastest
+target x86_64 haswell
+
+function %stack_load_and_store() {
+           ss0 = explicit_slot 8, offset 0
+
+ebb0:
+   v0 = stack_load.i64 ss0
+
+; check: v1 = stack_addr.i64 ss0
+; check: v0 = load.i64 notrap aligned v1
+
+   stack_store.i64 v0, ss0
+
+; check: v2 = stack_addr.i64 ss0
+; check: store notrap aligned v0, v2
+
+   return
+}

--- a/lib/codegen/meta/base/legalize.py
+++ b/lib/codegen/meta/base/legalize.py
@@ -80,6 +80,10 @@ expand.custom_legalize(insts.select, 'expand_select')
 expand.custom_legalize(insts.f32const, 'expand_fconst')
 expand.custom_legalize(insts.f64const, 'expand_fconst')
 
+# Custom expansions for stack memory accesses.
+expand.custom_legalize(insts.stack_load, 'expand_stack_load')
+expand.custom_legalize(insts.stack_store, 'expand_stack_store')
+
 x = Var('x')
 y = Var('y')
 a = Var('a')

--- a/lib/codegen/meta/isa/x86/encodings.py
+++ b/lib/codegen/meta/isa/x86/encodings.py
@@ -437,6 +437,15 @@ X86_64.enc(base.globalsym_addr.i64, *r.got_gvaddr8.rex(0x8b, w=1),
            isap=is_pic)
 
 #
+# Stack addresses.
+#
+# TODO: Add encoding rules for stack_load and stack_store, so that they
+# don't get legalized to stack_addr + load/store.
+#
+X86_32.enc(base.stack_addr.i32, *r.spaddr4_id(0x8d))
+X86_64.enc(base.stack_addr.i64, *r.spaddr8_id.rex(0x8d, w=1))
+
+#
 # Call/return
 #
 


### PR DESCRIPTION
This provides basic implementations for the stack access instructions. More optimal sequences are possible but these should be enough to get things started.

Fixes #181. Fixes #368.