### PR TITLE
Add support for macho relocations.

### DIFF
--- a/filetests/isa/x86/binary32.cton
+++ b/filetests/isa/x86/binary32.cton
@@ -352,7 +352,7 @@ ebb0:
     [-,%rsi]             v351 = bint.i32 v301   ; bin: 0f b6 f2
 
     ; asm: call foo
-    call fn0()                                  ; bin: stk_ovf e8 PCRel4(%foo-4) 00000000
+    call fn0()                                  ; bin: stk_ovf e8 CallPCRel4(%foo-4) 00000000
 
     ; asm: movl $0, %ecx
     [-,%rcx]            v400 = func_addr.i32 fn0        ; bin: b9 Abs4(%foo) 00000000

--- a/filetests/isa/x86/binary64-pic.cton
+++ b/filetests/isa/x86/binary64-pic.cton
@@ -30,7 +30,7 @@ ebb0:
     ; Colocated functions.
 
     ; asm: call foo
-    call fn1()                                  ; bin: stk_ovf e8 PCRel4(%bar-4) 00000000
+    call fn1()                                  ; bin: stk_ovf e8 CallPCRel4(%bar-4) 00000000
 
     ; asm: lea 0x0(%rip), %rax
     [-,%rax]            v0 = func_addr.i64 fn1        ; bin: 48 8d 05 PCRel4(%bar-4) 00000000
@@ -49,7 +49,7 @@ ebb0:
     ; Non-colocated functions.
 
     ; asm: call foo@PLT
-    call fn0()                                  ; bin: stk_ovf e8 PLTRel4(%foo-4) 00000000
+    call fn0()                                  ; bin: stk_ovf e8 CallPLTRel4(%foo-4) 00000000
 
     ; asm: mov 0x0(%rip), %rax
     [-,%rax]            v100 = func_addr.i64 fn0        ; bin: 48 8b 05 GOTPCRel4(%foo-4) 00000000

--- a/filetests/isa/x86/binary64.cton
+++ b/filetests/isa/x86/binary64.cton
@@ -485,7 +485,7 @@ ebb0:
     ; Colocated functions.
 
     ; asm: call bar
-    call fn1()                                  ; bin: stk_ovf e8 PCRel4(%bar-4) 00000000
+    call fn1()                                  ; bin: stk_ovf e8 CallPCRel4(%bar-4) 00000000
 
     ; asm: lea 0x0(%rip), %rcx
     [-,%rcx]            v400 = func_addr.i64 fn1        ; bin: 48 8d 0d PCRel4(%bar-4) 00000000

--- a/lib/codegen/meta/isa/x86/recipes.py
+++ b/lib/codegen/meta/isa/x86/recipes.py
@@ -1357,7 +1357,7 @@ call_id = TailRecipe(
         PUT_OP(bits, BASE_REX, sink);
         // The addend adjusts for the difference between the end of the
         // instruction and the beginning of the immediate field.
-        sink.reloc_external(Reloc::X86PCRel4,
+        sink.reloc_external(Reloc::X86CallPCRel4,
                             &func.dfg.ext_funcs[func_ref].name,
                             -4);
         sink.put4(0);
@@ -1368,7 +1368,7 @@ call_plt_id = TailRecipe(
         emit='''
         sink.trap(TrapCode::StackOverflow, func.srclocs[inst]);
         PUT_OP(bits, BASE_REX, sink);
-        sink.reloc_external(Reloc::X86PLTRel4,
+        sink.reloc_external(Reloc::X86CallPLTRel4,
                             &func.dfg.ext_funcs[func_ref].name,
                             -4);
         sink.put4(0);

--- a/lib/codegen/src/binemit/mod.rs
+++ b/lib/codegen/src/binemit/mod.rs
@@ -33,10 +33,12 @@ pub enum Reloc {
     Abs8,
     /// x86 PC-relative 4-byte
     X86PCRel4,
+    /// x86 call to PC-relative 4-byte
+    X86CallPCRel4,
+    /// x86 call to PLT-relative 4-byte
+    X86CallPLTRel4,
     /// x86 GOT PC-relative 4-byte
     X86GOTPCRel4,
-    /// x86 PLT-relative 4-byte
-    X86PLTRel4,
     /// Arm32 call target
     Arm32Call,
     /// Arm64 call target
@@ -53,8 +55,9 @@ impl fmt::Display for Reloc {
             Reloc::Abs4 => write!(f, "Abs4"),
             Reloc::Abs8 => write!(f, "Abs8"),
             Reloc::X86PCRel4 => write!(f, "PCRel4"),
+            Reloc::X86CallPCRel4 => write!(f, "CallPCRel4"),
+            Reloc::X86CallPLTRel4 => write!(f, "CallPLTRel4"),
             Reloc::X86GOTPCRel4 => write!(f, "GOTPCRel4"),
-            Reloc::X86PLTRel4 => write!(f, "PLTRel4"),
             Reloc::Arm32Call | Reloc::Arm64Call | Reloc::RiscvCall => write!(f, "Call"),
         }
     }

--- a/lib/simplejit/src/backend.rs
+++ b/lib/simplejit/src/backend.rs
@@ -269,7 +269,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
                         write_unaligned(at as *mut u64, what as u64)
                     };
                 }
-                Reloc::X86PCRel4 => {
+                Reloc::X86PCRel4 | Reloc::X86CallPCRel4 => {
                     // TODO: Handle overflow.
                     let pcrel = ((what as isize) - (at as isize)) as i32;
                     #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
@@ -277,7 +277,7 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
                         write_unaligned(at as *mut i32, pcrel)
                     };
                 }
-                Reloc::X86GOTPCRel4 | Reloc::X86PLTRel4 => panic!("unexpected PIC relocation"),
+                Reloc::X86GOTPCRel4 | Reloc::X86CallPLTRel4 => panic!("unexpected PIC relocation"),
                 _ => unimplemented!(),
             }
         }
@@ -334,9 +334,10 @@ impl<'simple_jit_backend> Backend for SimpleJITBackend {
                                 write_unaligned(at as *mut u64, what as u64)
                             };
                         }
-                        Reloc::X86PCRel4 | Reloc::X86GOTPCRel4 | Reloc::X86PLTRel4 => {
-                            panic!("unexpected text relocation in data")
-                        }
+                        Reloc::X86PCRel4
+                        | Reloc::X86CallPCRel4
+                        | Reloc::X86GOTPCRel4
+                        | Reloc::X86CallPLTRel4 => panic!("unexpected text relocation in data"),
                         _ => unimplemented!(),
                     }
                 }


### PR DESCRIPTION
This requires splitting X86PCRel4 into two separate relocations, to
distinguish the case where the instruction is a call, as Mach-O uses a
different relocation in that case.

This also makes it explicit that only x86-64 relocations are supported
currently.