### PR TITLE
Support systems which don't have a "python" command.

### DIFF
--- a/lib/codegen/meta/check.sh
+++ b/lib/codegen/meta/check.sh
@@ -5,7 +5,8 @@ cd "$topdir"
 
 function runif {
     if type "$1" > /dev/null; then
-        echo "   === $1 ==="
+        version=$("$1" --version 2>&1)
+        echo "   === $1: $version ==="
         "$@"
     else
         echo "$1 not found"
@@ -19,7 +20,7 @@ runif flake8 .
 runif mypy --py2 build.py
 
 # Python unit tests.
-runif python -m unittest discover
+runif python2.7 -m unittest discover
 
 # Then run the unit tests again with Python 3.
 # We get deprecation warnings about assertRaisesRegexp which was renamed in

--- a/test-all.sh
+++ b/test-all.sh
@@ -46,7 +46,7 @@ else
     needcheck=yes
 fi
 if [ -n "$needcheck" ]; then
-    banner "$(python --version 2>&1), $(python3 --version 2>&1)"
+    banner "Checking python source files"
     "$topdir/lib/codegen/meta/check.sh"
     touch "$tsfile" || echo no target directory
 fi


### PR DESCRIPTION
Add support for finding an appropriate python command on systems which
don't have "python". Try "python3" and "python2.7".

Fixed #381.