### PR TITLE
Update wabt to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0.8"
 serde_derive = "1.0.8"
 term = "0.5.1"
 capstone = { version = "0.4", optional = true }
-wabt = { version = "0.3", optional = true }
+wabt = { version = "0.4", optional = true }
 target-lexicon = "0.0.2"
 
 [features]

--- a/lib/wasm/Cargo.toml
+++ b/lib/wasm/Cargo.toml
@@ -18,7 +18,7 @@ failure_derive = { version = "0.1.1", default-features = false }
 target-lexicon = { version = "0.0.2", default-features = false }
 
 [dev-dependencies]
-wabt = "0.3"
+wabt = "0.4"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This fixes compilation on system with GCC 8.

See https://github.com/pepyakin/wabt-rs/issues/15